### PR TITLE
fix(terminal): Resolve issue with terminal cursor

### DIFF
--- a/lua/nightfox/theme.lua
+++ b/lua/nightfox/theme.lua
@@ -26,8 +26,8 @@ function M.setup(config)
     DiffDelete = { bg = c.diff.delete }, -- diff mode: Deleted line |diff.txt|
     DiffText = { bg = c.diff.text }, -- diff mode: Changed text within a changed line |diff.txt|
     EndOfBuffer = { fg = c.bg }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
-    TermCursor = {}, -- cursor in a focused terminal
-    TermCursorNC = {}, -- cursor in an unfocused terminal
+    -- TermCursor = {}, -- cursor in a focused terminal
+    -- TermCursorNC = {}, -- cursor in an unfocused terminal
     ErrorMsg = { fg = c.error }, -- error messages on the command line
     VertSplit = { fg = c.border }, -- the column separating vertically split windows
     Folded = { fg = c.blue, bg = c.fg_gutter }, -- line used for closed folds


### PR DESCRIPTION
There is an issue in the theme file that was setting `TermCursor` and
`TermCursorNC` and there were no values. Removing these files resolves
the issue.

Fixes: #7