### PR TITLE
fix: Darken DiffText to make readable

### DIFF
--- a/lua/nightfox/colors/nightfox.lua
+++ b/lua/nightfox/colors/nightfox.lua
@@ -69,7 +69,7 @@ function M.setup(config)
     add = util.darken(colors.green, 0.15),
     delete = util.darken(colors.red, 0.15),
     change = util.darken(colors.blue, 0.15),
-    text = colors.blue,
+    text = util.darken(colors.blue, 0.4),
   }
 
   colors.gitSigns = {

--- a/lua/nightfox/colors/nordfox.lua
+++ b/lua/nightfox/colors/nordfox.lua
@@ -81,7 +81,7 @@ function M.setup(config)
     add = util.darken(colors.green, 0.15),
     delete = util.darken(colors.red, 0.15),
     change = util.darken(colors.blue, 0.15),
-    text = colors.blue,
+    text = util.darken(colors.blue, 0.4),
   }
 
   colors.gitSigns = {

--- a/lua/nightfox/colors/palefox.lua
+++ b/lua/nightfox/colors/palefox.lua
@@ -81,7 +81,7 @@ function M.setup(config)
     add = util.darken(colors.green, 0.15),
     delete = util.darken(colors.red, 0.15),
     change = util.darken(colors.blue, 0.15),
-    text = colors.blue,
+    text = util.darken(colors.blue, 0.5),
   }
 
   colors.gitSigns = {


### PR DESCRIPTION
There was an issue with diff text being set to blue, making the text
unreadable. This change solved the issue by darkening the diff.text
color to make it more readable.

Fixes: #9

Result of new change

## Nightfox

![nightfox-fixed](https://user-images.githubusercontent.com/2746374/129989074-3e5ed00d-5bca-4bfd-8f19-6822b036c49c.png)

## Nordfox

![nordfox-fixed](https://user-images.githubusercontent.com/2746374/129989091-ad24899a-75d2-4ce1-aed4-2386a4b45a64.png)

## Palefox

![palefox-fixed](https://user-images.githubusercontent.com/2746374/129989115-39d19b5b-0fd6-4401-9afc-2e230af6c15f.png)

