### PR TITLE
fix(autocmd): Do autocmd `ColorScheme` after load

### DIFF
--- a/lua/nightfox/util.lua
+++ b/lua/nightfox/util.lua
@@ -186,6 +186,8 @@ function util.load(theme)
   if theme.config.terminal_colors then
     util.terminal(theme)
   end
+
+  vim.cmd([[doautocmd ColorScheme]])
 end
 
 return util


### PR DESCRIPTION
This fixes an issue with lualine where the bar's colors would be cleared
after util.load was called. Making sure that `ColorScheme` autocmd is
executed solved that issue.