### PR TITLE
refactor: Configuration moved to lua

### DIFF
--- a/colors/nightfox.vim
+++ b/colors/nightfox.vim
@@ -1,12 +1,15 @@
 lua << EOF
-package.loaded['nightfox'] = nil
-package.loaded['nightfox.colors'] = nil
-package.loaded["nightfox.colors.nightfox"] = nil
-package.loaded["nightfox.colors.nordfox"] = nil
-package.loaded["nightfox.colors.voidfox"] = nil
-package.loaded['nightfox.config'] = nil
-package.loaded['nightfox.theme'] = nil
-package.loaded['nightfox.util'] = nil
+-- Useful for me when I am trying to debug and reload my changes
+if vim.g.nightfox_debug == true then
+  package.loaded['nightfox'] = nil
+  package.loaded['nightfox.colors'] = nil
+  package.loaded["nightfox.colors.nightfox"] = nil
+  package.loaded["nightfox.colors.nordfox"] = nil
+  package.loaded["nightfox.colors.voidfox"] = nil
+  package.loaded['nightfox.config'] = nil
+  package.loaded['nightfox.theme'] = nil
+  package.loaded['nightfox.util'] = nil
+end
 
-require('nightfox').set()
+require('nightfox').load()
 EOF

--- a/lua/lightline/colorscheme/nightfox.lua
+++ b/lua/lightline/colorscheme/nightfox.lua
@@ -1,4 +1,4 @@
-local colors = require("nightfox.colors").setup()
+local colors = require("nightfox.colors").load()
 
 local nightfox = {}
 

--- a/lua/lualine/themes/nightfox.lua
+++ b/lua/lualine/themes/nightfox.lua
@@ -1,4 +1,4 @@
-local colors = require("nightfox.colors").setup()
+local colors = require("nightfox.colors").load()
 
 local nightfox = {}
 

--- a/lua/nightfox/colors/init.lua
+++ b/lua/nightfox/colors/init.lua
@@ -1,25 +1,50 @@
-local color = {}
+local M = {}
 
-color.styles = {
+M.foxes = {
   "nightfox",
   "nordfox",
   "palefox",
 }
 
-function color.setup(config)
-  config = config or require("nightfox.config")
+-- Returns a color table based on the name provided
+-- This returns the initial colors defined by the colorscheme
+-- without overrides from the configuration
+-- If name is not found will default to nightfox
+-- If the fox's name is invalid the it will return nightfox colors
+function M.init(name)
+  name = name or require("nightfox.config").options.fox
 
-  if config.style == "randfox" then
-    local index = math.random(#color.style)
-    return require("nightfox.colors." .. color.styles[index]).setup()
+  if name == "randfox" then
+    local index = math.random(#M.foxes)
+    return require("nightfox.colors." .. M.foxes[index]).init()
   end
 
-  if vim.tbl_contains(color.styles, config.style) then
-    return require("nightfox.colors." .. config.style).setup()
+  if vim.tbl_contains(M.foxes, name) then
+    return require("nightfox.colors." .. name).init()
   end
 
-  print("[Nightfox]: Unknown style: " .. config.style)
-  return require("nightfox.colors.nightfox").setup()
+  print("Nightfox: colorscheme " .. name .. " was not found")
+  return require("nightfox.colors.nightfox").init()
 end
 
-return color
+-- Return color table based on the name provided
+-- If no name is provided it will return the fox set in the config
+-- If the fox defined in the configuration is invalid the it will return nightfox colors
+-- @param name string (optional)
+function M.load(name)
+  name = name or require("nightfox.config").options.fox
+
+  if name == "randfox" then
+    local index = math.random(#M.foxes)
+    return require("nightfox.colors." .. M.foxes[index]).load()
+  end
+
+  if vim.tbl_contains(M.foxes, name) then
+    return require("nightfox.colors." .. name).load()
+  end
+
+  print("Nightfox: colorscheme " .. name .. " was not found")
+  return require("nightfox.colors.nightfox").load()
+end
+
+return M

--- a/lua/nightfox/colors/nightfox.lua
+++ b/lua/nightfox/colors/nightfox.lua
@@ -2,8 +2,9 @@ local util = require("nightfox.util")
 
 local M = {}
 
-function M.setup(config)
-  config = config or require("nightfox.config")
+-- Return the initial colors of the colorscheme. This is the default defined colors
+-- without the color overrides from the configuration.
+function M.init()
 
   -- References:
   -- https://coolors.co/393b44-c94f6d-81b29a-dbc074-719cd6-9d79d6-63cdcf-dfdfe0-f4a261-d67ad2
@@ -96,9 +97,6 @@ function M.setup(config)
   colors.bg_popup = colors.bg_alt
   colors.bg_statusline = colors.bg_alt
 
-  -- Sidebar and Floats are configurable
-  -- colors.bg_sidebar = config.darkSidebar and colors.bg_alt or colors.bg
-  -- colors.bg_float = config.darkFloat and colors.bg_alt or colors.bg
   colors.bg_sidebar = colors.bg_alt
   colors.bg_float = colors.bg_alt
 
@@ -113,6 +111,15 @@ function M.setup(config)
 
   colors.variable = colors.white
 
+  return colors
+end
+
+-- Returns the completed colors with the overrides from the configuration
+-- @param config table
+function M.load(config)
+  config = config or require("nightfox.config").options
+
+  local colors = M.init()
   util.color_overrides(colors, config)
 
   return colors

--- a/lua/nightfox/colors/nordfox.lua
+++ b/lua/nightfox/colors/nordfox.lua
@@ -2,9 +2,9 @@ local util = require("nightfox.util")
 
 local M = {}
 
-function M.setup(config)
-  config = config or require("nightfox.config")
-
+-- Return the initial colors of the colorscheme. This is the default defined colors
+-- without the color overrides from the configuration.
+function M.init()
   -- Reference:
   -- https://i.imgur.com/LzJYkpS.jpeg
   -- https://coolors.co/3b4252-bf616a-a3be8c-ebcb8b-81a1c1-b48ead-88c0d0-e5e9f0-c9826b-d67ad2
@@ -98,9 +98,6 @@ function M.setup(config)
   colors.bg_popup = colors.bg_alt
   colors.bg_statusline = colors.bg_alt
 
-  -- Sidebar and Floats are configurable
-  -- colors.bg_sidebar = config.darkSidebar and colors.bg_alt or colors.bg
-  -- colors.bg_float = config.darkFloat and colors.bg_alt or colors.bg
   colors.bg_sidebar = colors.bg_alt
   colors.bg_float = colors.bg_alt
 
@@ -115,6 +112,15 @@ function M.setup(config)
 
   colors.variable = colors.white
 
+  return colors
+end
+
+-- Returns the completed colors with the overrides from the configuration
+-- @param config table
+function M.load(config)
+  config = config or require("nightfox.config").options
+
+  local colors = M.init()
   util.color_overrides(colors, config)
 
   return colors

--- a/lua/nightfox/colors/palefox.lua
+++ b/lua/nightfox/colors/palefox.lua
@@ -2,9 +2,9 @@ local util = require("nightfox.util")
 
 local M = {}
 
-function M.setup(config)
-  config = config or require("nightfox.config")
-
+-- Return the initial colors of the colorscheme. This is the default defined colors
+-- without the color overrides from the configuration.
+function M.init()
   -- Reference:
   -- https://coolors.co/3b3a32-f1756f-6de874-f0e656-a381ff-ff87b1-7ef5b8-c7b7c7-f5b87f-ffb8d1
 
@@ -115,6 +115,15 @@ function M.setup(config)
 
   colors.variable = colors.white
 
+  return colors
+end
+
+-- Returns the completed colors with the overrides from the configuration
+-- @param config table
+function M.load(config)
+  config = config or require("nightfox.config").options
+
+  local colors = M.init()
   util.color_overrides(colors, config)
 
   return colors

--- a/lua/nightfox/config.lua
+++ b/lua/nightfox/config.lua
@@ -1,33 +1,61 @@
----@class Config
-local config
+local M = {}
 
--- shim vim for kitty and other generators
-vim = vim or { g = {}, o = {} }
-
-local function opt(key, default)
-  key = "nightfox_" .. key
-  if vim.g[key] == nil then
-    return default
-  end
-  if vim.g[key] == 0 then
-    return false
-  end
-  return vim.g[key]
-end
-
-config = {
-  style = opt("style", "nightfox"),
-  transparent = opt("transparent", false),
-  comment_style = opt("italic_comments", false) and "italic" or "NONE",
-  function_style = opt("italic_functions", false) and "italic" or "NONE",
-  keyword_style = opt("italic_keywords", false) and "italic" or "NONE",
-  string_style = opt("italic_strings", false) and "italic" or "NONE",
-  variable_style = opt("italic_variables", false) and "italic" or "NONE",
-  terminal_colors = opt("terminal_colors", true),
-  color_delimiter = opt("color_delimiter", ""),
-  colors = opt("colors", {}),
-  -- hide_inactive_statusline = opt("hide_inactive_statusline", false),
-  -- sidebars = opt("sidebars", {}),
+local config = {
+  fox = "nightfox", -- Which fox style should be applied
+  transparent = false, -- Disable setting the background color
+  terminal_colors = true, -- Configure the colors used when opening :terminal
+  styles = {
+    comments = "NONE", -- Style that is applied to comments: see `highlight-args` for options
+    functions = "NONE", -- Style that is applied to functions: see `highlight-args` for options
+    keywords = "NONE", -- Style that is applied to keywords: see `highlight-args` for options
+    strings = "NONE", -- Style that is applied to strings: see `highlight-args` for options
+    variables = "NONE", -- Style that is applied to variables: see `highlight-args` for options
+  },
+  colors = {}, -- Override default colors
+  hlgroups = {}, -- Override highlight groups
 }
 
-return config
+M.options = {}
+
+function M.set_options(opts)
+  opts = opts or {}
+  M.options = vim.tbl_deep_extend("force", {}, config, opts)
+end
+
+function M.check_depricated_options()
+  local keys = {
+    "style",
+    "transparent",
+    "italic_comments",
+    "italic_functions",
+    "italic_keywords",
+    "italic_strings",
+    "italic_variables",
+    "terminal_colors",
+    "color_delimiter",
+    "colors",
+  }
+
+  local results = {}
+
+  for _, k in ipairs(keys) do
+    local key = "nightfox_" .. k
+    if vim.g[key] ~= nil then
+      table.insert(
+        results,
+        "Nightfox: Warning config using '" .. key .. "' is deprecated in favor of lua setup configuration"
+      )
+    end
+  end
+
+  if #results > 0 then
+    local msg = table.concat(results, "\n")
+    print(msg)
+  end
+end
+
+M.check_depricated_options()
+
+M.set_options(config)
+
+return M

--- a/lua/nightfox/extras/init.lua
+++ b/lua/nightfox/extras/init.lua
@@ -1,6 +1,6 @@
 package.path = "./lua/?/init.lua;./lua/?.lua"
 
-local config = require("nightfox.config")
+local color_module = require("nightfox.colors")
 
 local function write(str, filename)
   print("[write]: extra/" .. filename)
@@ -19,13 +19,10 @@ local extras = {
   xresources = "Xresources",
 }
 
-local styles = { "nightfox", "nordfox", "palefox" }
-
 for extra, ext in pairs(extras) do
   local plugin = require("nightfox.extras." .. extra)
-  for _, style in ipairs(styles) do
-    config.style = style
-    local colors = require("nightfox.colors").setup(config)
+  for _, style in ipairs(color_module.foxes) do
+    local colors = color_module.init(style)
     local filename = string.format("%s/nightfox_%s.%s", style, extra, ext)
     write(plugin.generate(colors), filename)
   end

--- a/lua/nightfox/init.lua
+++ b/lua/nightfox/init.lua
@@ -1,9 +1,23 @@
+package.loaded["nightfox.config"] = nil
 local util = require("nightfox.util")
 
 local M = {}
 
-function M.set()
-  local theme = require("nightfox.theme").setup()
+-- Set the configuration values for nightfox.
+-- This functions sets the configuration options for nightfox. These settings will be used when the colorscheme is
+-- applied. The colorscheme is applied with the `load` function.
+-- @param opts table
+function M.setup(opts)
+  require("nightfox.config").set_options(opts)
+end
+
+-- Loads colorscheme and applies the highlight groups.
+-- If a name is passed it will override what was set in the configuration setup.
+-- @param name string
+function M.load(name)
+  local colors = require("nightfox.colors").load(name)
+  local theme = require("nightfox.theme").apply(colors)
+
   util.load(theme)
 end
 

--- a/lua/nightfox/theme.lua
+++ b/lua/nightfox/theme.lua
@@ -1,18 +1,18 @@
-local colors = require("nightfox.colors")
 local util = require("nightfox.util")
 
 local M = {}
 
-function M.setup(config)
-  config = config or require("nightfox.config")
+function M.apply(colors, config)
+  config = config or require("nightfox.config").options
+  colors = colors or require("nightfox.colors").load()
 
   local theme = {}
   theme.config = config
-  theme.colors = colors.setup(config)
+  theme.colors = colors
   local c = theme.colors
 
-  theme.base = {
-    Comment = { fg = c.comment, style = config.comment_style }, -- any comment
+  theme.groups = {
+    Comment = { fg = c.comment, style = config.styles.comments }, -- any comment
     ColorColumn = { bg = c.bg_visual }, -- used for the columns set with 'colorcolumn'
     Conceal = { fg = c.black }, -- placeholder characters substituted for concealed text (see 'conceallevel')
     Cursor = { fg = c.bg, bg = c.fg }, -- character under the cursor
@@ -80,21 +80,21 @@ function M.setup(config)
     -- Uncomment and edit if you want more specific syntax highlighting.
 
     Constant = { fg = c.orange }, -- (preferred) any constant
-    String = { fg = c.green, style = config.string_style }, --   a string constant: "this is a string"
+    String = { fg = c.green, style = config.styles.strings }, --   a string constant: "this is a string"
     Character = { fg = c.green }, --  a character constant: 'c', '\n'
     Number = { fg = c.orange_br }, --   a number constant: 234, 0xff
     Float = { fg = c.orange_br }, --    a floating point constant: 2.3e10
     Boolean = { fg = c.orange_br }, --  a boolean constant: TRUE, false
 
-    Identifier = { fg = c.cyan, style = config.variable_style }, -- (preferred) any variable name
-    Function = { fg = c.blue, style = config.function_style }, -- function name (also: methods for classes)
+    Identifier = { fg = c.cyan, style = config.styles.variables }, -- (preferred) any variable name
+    Function = { fg = c.blue, style = config.styles.functions }, -- function name (also: methods for classes)
 
     Statement = { fg = c.magenta_br }, -- (preferred) any statement
     Conditional = { fg = c.magenta_br }, --  if, then, else, endif, switch, etc.
     Repeat = { fg = c.magenta_br }, --   for, do, while, etc.
     Label = { fg = c.magenta_br }, --    case, default, etc.
     Operator = { fg = c.fg_alt }, -- "sizeof", "+", "*", etc.
-    Keyword = { fg = c.magenta, style = config.keyword_style }, --  any other keyword
+    Keyword = { fg = c.magenta, style = config.styles.keywords }, --  any other keyword
     -- Exception     = { }, --  try, catch, throw
 
     PreProc = { fg = c.pink }, -- (preferred) generic Preprocessor
@@ -211,8 +211,8 @@ function M.setup(config)
     TSFuncBuiltin = { fg = c.cyan }, -- For builtin functions: `table.insert` in Lua.
     TSFuncMacro = { fg = c.red }, -- For macro defined fuctions (calls and definitions): each `macro_rules` in Rust.
     -- TSInclude           = { };    -- For includes: `#include` in C, `use` or `extern crate` in Rust, or `require` in Lua.
-    TSKeyword = { fg = c.magenta, style = config.keyword_style }, -- For keywords that don't fall in previous categories.
-    TSKeywordFunction = { fg = c.magenta, style = config.function_style }, -- For keywords used to define a fuction.
+    TSKeyword = { fg = c.magenta, style = config.styles.keywords }, -- For keywords that don't fall in previous categories.
+    TSKeywordFunction = { fg = c.magenta, style = config.styles.functions }, -- For keywords used to define a fuction.
     TSLabel = { fg = c.blue }, -- For labels: `label:` in C and `:label:` in Lua.
     -- TSMethod            = { };    -- For method calls and definitions.
     TSNamespace = { fg = c.cyan }, -- For identifiers referring to modules and namespaces.
@@ -223,17 +223,17 @@ function M.setup(config)
     -- TSParameterReference= { };    -- For references to parameters of a function.
     TSProperty = { fg = c.green }, -- Same as `TSField`.
     tomlTSProperty = { fg = c.blue }, -- Differentiates between string and properties
-    TSPunctDelimiter = { fg = util.string_to_color(c, config.color_delimiter, c.fg_alt) }, -- For delimiters ie: `.`
+    TSPunctDelimiter = { fg = c.fg_alt }, -- For delimiters ie: `.`
     TSPunctBracket = { fg = c.fg_alt }, -- For brackets and parens.
     TSPunctSpecial = { fg = c.white }, -- For special punctutation that does not fall in the catagories before.
     -- TSRepeat            = { };    -- For keywords related to loops.
     -- TSString            = { };    -- For strings.
-    TSStringRegex = { fg = c.blue, style = config.string_style }, -- For regexes.
-    TSStringEscape = { fg = c.magenta, style = config.string_style }, -- For escape characters within a string.
+    TSStringRegex = { fg = c.blue, style = config.styles.strings }, -- For regexes.
+    TSStringEscape = { fg = c.magenta, style = config.styles.strings }, -- For escape characters within a string.
     -- TSSymbol            = { };    -- For identifiers referring to symbols or atoms.
     -- TSType              = { };    -- For types.
     TSTypeBuiltin = { fg = c.cyan }, -- For builtin types.
-    TSVariable = { style = config.variable_style }, -- Any variable name that does not have another highlight.
+    TSVariable = { style = config.styles.variables }, -- Any variable name that does not have another highlight.
     TSVariableBuiltin = { fg = c.red }, -- Variable names that are defined by the languages, like `this` or `self`.
 
     -- TSTag               = { };    -- Tags like html tag names.
@@ -246,9 +246,9 @@ function M.setup(config)
     -- TSTitle             = { };    -- Text that is part of a title.
     -- TSLiteral           = { };    -- Literal text.
     -- TSURI               = { };    -- Any URI like a link or email.
-  }
 
-  theme.plugins = {
+    -- Plugins ------------------------------------------------------------------------------------
+
     -- LspTrouble
     LspTroubleText = { fg = c.fg_alt },
     LspTroubleCount = { fg = c.magenta, bg = c.fg_gutter },

--- a/lua/nightfox/util.lua
+++ b/lua/nightfox/util.lua
@@ -144,6 +144,23 @@ function util.template(str, table)
   end))
 end
 
+-- Template values in a table recursivly
+---@param table table the table to be replaced
+---@param values table the values to be replaced by the template strings in the table passed in
+function util.template_table(table, values)
+  -- if the value passed is a string the return templated resolved string
+  if type(table) == "string" then
+    return util.template(table, values)
+  end
+
+  -- If the table passed in is a table then iterate though the children and call template table
+  for key, value in pairs(table) do
+    table[key] = util.template_table(value, values)
+  end
+
+  return table
+end
+
 function util.syntax(tbl)
   for group, colors in pairs(tbl) do
     util.highlight(group, colors)
@@ -180,8 +197,10 @@ function util.load(theme)
   vim.o.termguicolors = true
   vim.g.colors_name = "nightfox"
 
-  util.syntax(theme.base)
-  util.syntax(theme.plugins)
+  local hlgroups = util.template_table(theme.config.hlgroups, theme.colors)
+  local groups = vim.tbl_deep_extend("force", theme.groups, hlgroups)
+
+  util.syntax(groups)
 
   if theme.config.terminal_colors then
     util.terminal(theme)

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ colorscheme nightfox
 
 ```lua
 -- From lua
-require('nightfox').set()
+require('nightfox').load()
 ```
 
 To enable `Nightfox` from `Lualine`:
@@ -100,100 +100,127 @@ To enable `Nightfox` from `Lightline`:
 let g:lightline = {'colorscheme': 'nightfox'}
 ```
 
-Note, the colorscheme's name is `nightfox`. Other styles are only set with the variable
-`nightfox_style`. Setting `colorscheme`, `lualine` or `lightline` theme to `nordfox` or `palefox` is invalid.
+> ❗️ `nightfox` is the only valid theme name. The other names are styles that can be set in the configuration.
 
 ## ⚙️ Configuration
 
-> ❗️ Configuration needs to be set BEFORE loading the color scheme with colorscheme nightfox
-
-Available options:
-
-| Option                       | Default      | Description                                                         |
-| ---------------------------- | ------------ | ------------------------------------------------------------------- |
-| nightfox_style               | `"nightfox"` | Which color style that will be applied                              |
-| nightfox_transparent         | `false`      | Disable setting the background color                                |
-| nightfox_terminal_colors     | `true`       | Configure the colors used when opening `:terminal` in neovim        |
-| nightfox_italic_comments     | `false`      | Make comments italic                                                |
-| nightfox_italic_functions    | `false`      | Make function calls and names italic                                |
-| nightfox_italic_keywords     | `false`      | Make keywords like if, for, while etc. italic                       |
-| nightfox_italic_strings      | `false`      | Make strings italic                                                 |
-| nightfox_italic_variables    | `false`      | Make variable names and identifiers italic                          |
-| nightfox_color_delimiter     | `""`         | Set `TSPunctDelimiter` to either hex color code or color name       |
-| nightfox_colors              | `{}`         | Override specific colors or groups                                  |
-
+Nightfox comes with default configuration values. You can view them here:
 
 ```lua
--- Example in lua
-vim.g.nightfox_style = "palefox"
-vim.g.nightfox_color_delimiter = "red"
-vim.g.nightfox_italic_comments = 1
-
--- Load the colorscheme
-require('nightfox').set()
+{
+  fox = "nightfox", -- Which fox style should be applied
+  transparent = false, -- Disable setting the background color
+  terminal_colors = true, -- Configure the colors used when opening :terminal
+  styles = {
+    comments = "NONE", -- Style that is applied to comments: see `highlight-args` for options
+    functions = "NONE", -- Style that is applied to functions: see `highlight-args` for options
+    keywords = "NONE", -- Style that is applied to keywords: see `highlight-args` for options
+    strings = "NONE", -- Style that is applied to strings: see `highlight-args` for options
+    variables = "NONE", -- Style that is applied to variables: see `highlight-args` for options
+  },
+  colors = {}, -- Override default colors
+  hlgroups = {}, -- Override highlight groups
+}
 ```
 
-```vim
-" Example in vim
-let g:nightfox_style = "palefox"
-let g:nightfox_color_delimiter = "red"
-let g:nightfox_italic_comments = 1
+You can override these values to suite your preferences. An example of this would be as follows:
 
-" Load the colorscheme
-colorscheme nightfox
+```lua
+local nightfox = require('nightfox')
+
+-- This function set the configuration of nightfox. If a value is not passed in the setup function
+-- it will be taken from the default configuration above
+nightfox.setup({
+  fox = "nordfox", -- change the colorscheme to use nordfox
+  styles = {
+    comments = "italic", -- change style of comments to be italic
+    keywords = "bold", -- change style of keywords to be bold
+    functions = "italic,bold" -- styles can be a comma separated list
+  },
+  colors = {
+    red = "#FF000", -- Override the red color for MAX POWER
+    bg_alt = "#000000",
+  },
+  hlgroup = {
+    TSPunctDelimiter = { fg = "${red}" }, -- Override a highlight group with the color red
+    LspCodeLens = { bg = "#000000" },
+  }
+})
+
+-- Load the configuration set above and apply the colorscheme
+nightfox.load()
 ```
+
+### General
+
+These are general settings and are unrelated to any group of settings.
+
+- `fox`: **{string}** The name of the fox you which to base the colorscheme on. See [Styles](#styles).
+- `transparent`: **{boolean}** If set to true the background color will not be set.
+- `terminal_colors`: **{boolean}** If set to true nightfox will set the terminal colors for `:terminal`
+
+### Styles
+
+These options set the style for their respecitve highlight groups. See `:help highlight-args`.
+
+- `comments`: **{string}** Style to the applied to comments
+- `functions`: **{string}** Style to the applied to functions
+- `keywords`: **{string}** Style to the applied to keywords
+- `strings`: **{string}** Style to the applied to strings
+- `variables`: **{string}** Style to the applied to variables
+
+### Colors
+
+`colors` is a table that defines hex color overrides for the colors returned by
+`require('nightfox.colors').load()`. To see what values can be overridden, use `vim.inspect` to
+print out the returned color table.
+
+```lua
+print(vim.inspect(require('nightfox.colors').init()))
+```
+
+Colors with the suffix `_br` are brighter colors. Colors with the suffix `_dm` are dimmer colors.
+
+To see what colors are defined to what highlight group you can reference the file
+[theme.lua](./lua/nightfox/theme.lua).
+
+### HLGroup
+
+`hlgroups` is a table that defines overrides for highlight groups. The table consists of the
+highlight group name as the key. The value is a table that defines optional values of the highlight
+group. These values can be:
+
+- `fg`: The foreground color of the highlight group
+- `bg`: The background color of the highlight group
+- `style`: The style applied to the highlight group (see `:help hightlight-args`)
+- `sp`: Special colors use in GUI. (see `:help hightlight-guisp`)
+
+To use a color defined by nightfox's you can use the template format: `${}`. Any value that you can
+override in the [colors](#colors) section can be added in the template format. Some examples would
+be: `${red}`, `${blue_br}`, `${bg_alt}`.
+
+To see examples of highlight groups that can be overridden reference the file
+[theme.lua](./lua/nightfox/theme.lua).
 
 ## ⚙️ Advanced Configuration
 
-### Inspect color object
+### Get color values from nightfox
 
-To inspect what colors are defined you can print the color object:
-
-```vim
-:lua print(vim.inspect(require('nightfox.colors').setup()))
-```
-
-### Override highlight group
-
-Nightfox does not have a builtin way to override highlight groups like it does for colors. However
-this can be done manually. Here is a documented example of overriding multiple highlight groups:
+There are different ways to get colors from nightfox. Here are some examples:
 
 ```lua
--- Setting the style you want the require colors will return
-vim.g.nightfox_style = "nordfox"
+-- Get the colors defined in nightfox with the color overrides from config applied
+local colors = require('nightfox.colors').load()
 
--- Overriding any colors you want
-vim.g.nightfox_colors = {
-  red = "#FF0000" -- Much red, such wow
-}
+-- Get the color of a specific theme with the color overrides applied from the config
+local colors = require('nightfox.colors').load('nordfox')
 
--- Set the colorscheme, This will set nightfox's config based on the variables above
-require('nightfox').set()
+-- Get the colors defined in nightfox without the color overrides applied from the config
+local colors = require('nightfox.colors').init()
 
--- Get the colors from nightfox that were set in the call above
-local colors = require("nightfox.colors").setup()
-
--- Get the util functions that the nightfox theme uses
-local util = require("nightfox.util")
-
--- Create a table with the highlight groups that you want to override and the highlight group keys.
--- Keys are the following: bg, fg, style and sp.
--- See `:help highlight-guisp` for more info.
-local overrides = {
-  String = { fg = colors.orange },
-  IncSearch = { bg = colors.magenta, fg = colors.black },
-}
-
--- Loop though table above and call nightfox's highlight util function
-for group, values in pairs(overrides) do
-  -- This function takes the values defined above and creates a vim.cmd highlight command.
-  util.highlight(group, values)
-end
+-- Get the color of a specific theme without the color overrides applied from the config
+local colors = require('nightfox.colors').init("nordfox")
 ```
-
-If you would like to see an example list of highlight groups that you override, check out the
-[theme.lua](./lua/nightfox/theme.lua) file.
-
 
 ## 🍬 Extra
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,6 @@
 # 🦊 Nightfox
 
+⚠️
 A dark Neovim theme written in lua.
 
 <div align="center">
@@ -149,6 +150,15 @@ nightfox.setup({
 
 -- Load the configuration set above and apply the colorscheme
 nightfox.load()
+```
+
+For configuration in `vimscript`, wrap the above example in a lua script block.
+
+```vim
+" vimscript
+lua << EOF
+-- example above here
+EOF
 ```
 
 ### General


### PR DESCRIPTION
⚠️BREAKING CHANGE⚠️

This pr outlines changes made to move configuration from global variables to lua setup and load functions. This change deprecates the old global variables in favor of the lua `setup` function. Nightfox prints a warning to the user about the depreciation.
An issue will be pinned about the deprecation.

New configuration looks like this:

```lua
local nightfox = require('nightfox')

nightfox.setup({
  fox = "nordfox"
})

nightfox.load()
```

Fixes #19 