### PR TITLE
Typo in readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -148,9 +148,9 @@ nightfox.setup({
     red = "#FF000", -- Override the red color for MAX POWER
     bg_alt = "#000000",
   },
-  hlgroup = {
+  hlgroups = {
     TSPunctDelimiter = { fg = "${red}" }, -- Override a highlight group with the color red
-    LspCodeLens = { bg = "#000000" },
+    LspCodeLens = { bg = "#000000", style = "italic" },
   }
 })
 


### PR DESCRIPTION
I fixed the typo `hlgroup` -> `hlgroups` and extended a bit the example to include style change (i.e. `italic`).