### PR TITLE
Fix DiagnosticUnderlineWarn and DiagnosticUnderlineInfo

### DIFF
--- a/lua/nightfox/theme.lua
+++ b/lua/nightfox/theme.lua
@@ -172,8 +172,8 @@ function M.apply(colors, config)
     DiagnosticVirtualTextHint = { bg = util.darken(c.hint, 0.1), fg = c.hint }, -- Used for "Hint" diagnostic virtual text
 
     DiagnosticUnderlineError = { style = "undercurl", sp = c.error }, -- Used to underline "Error" diagnostics
-    DiagnosticUnderlineWarning = { style = "undercurl", sp = c.warning }, -- Used to underline "Warning" diagnostics
-    DiagnosticUnderlineInformation = { style = "undercurl", sp = c.info }, -- Used to underline "Information" diagnostics
+    DiagnosticUnderlineWarn = { style = "undercurl", sp = c.warning }, -- Used to underline "Warning" diagnostics
+    DiagnosticUnderlineInfo = { style = "undercurl", sp = c.info }, -- Used to underline "Information" diagnostics
     DiagnosticUnderlineHint = { style = "undercurl", sp = c.hint }, -- Used to underline "Hint" diagnostics
 
     -- Support versions of Neovim prior to this change:


### PR DESCRIPTION
https://github.com/neovim/neovim/blob/5fd4557573c73a6b41b702b1ee39151b5bd7e5fd/src/nvim/syntax.c#L6224-L6225

These group names were off