### PR TITLE
fix(dayfox): Darken dayfox colors for readability

### DIFF
--- a/lua/nightfox/colors/dayfox.lua
+++ b/lua/nightfox/colors/dayfox.lua
@@ -7,51 +7,51 @@ local M = {}
 function M.init()
   -- Reference:
   -- https://github.com/Rashad-707/rhombuses/tree/c147ffdcc1
-  -- https://coolors.co/1d344f-c98093-7ca198-CE8D52-6080b0-8e6f98-6ca8cf-cdd1d5-EE896D-D685AF
+  -- https://github.com/Rashad-707/dotfiles/tree/df5ac6b
 
   -- stylua: ignore
   local colors = {
     meta       = { name = "dayfox", light = true },
 
     none       = "NONE",
-    bg         = "#E8EAEC", -- "#EEEFF1"
+    bg         = "#E6E6E6",
 
     fg         = "#1D344F",
-    fg_gutter  = "#B9BCC2",
+    fg_gutter  = "#AAACB3",
 
     black      = "#1d344f",
-    red        = "#c98093",
-    green      = "#7ca198",
-    yellow     = "#CE8D52",
+    red        = "#B95D76",
+    green      = "#618774",
+    yellow     = "#BC8C4E", -- "#c29860",
     blue       = "#6080b0",
     magenta    = "#8e6f98",
-    cyan       = "#6ca8cf",
+    cyan       = "#6CA7BD",
     white      = "#cdd1d5",
-    orange     = "#EE896D",
+    orange     = "#E3786C",
     pink       = "#D685AF",
 
     -- +10 brightness, +10 saturation
     black_br   = "#24476F",
-    red_br     = "#D48A9D",
-    green_br   = "#82B2A6",
-    yellow_br  = "#D8985C",
+    red_br     = "#C76882",
+    green_br   = "#629F81",
+    yellow_br  = "#D78614",
     blue_br    = "#678ABF",
     magenta_br = "#9F75AC",
-    cyan_br    = "#77B2D9",
+    cyan_br    = "#74B2C9",
     white_br   = "#CFD6DD",
-    orange_br  = "#F29379",
+    orange_br  = "#E8857A",
     pink_br    = "#DE8DB7",
 
     -- -10 brightness, -10 saturation
     black_dm   = "#1C2F44",
-    red_dm     = "#BB6F83",
-    green_dm   = "#6F9289",
-    yellow_dm  = "#C07E41",
+    red_dm     = "#AC5169",
+    green_dm   = "#597668",
+    yellow_dm  = "#9F6719",
     blue_dm    = "#54729F",
     magenta_dm = "#806589",
-    cyan_dm    = "#5A99C2",
+    cyan_dm    = "#5A99B0",
     white_dm   = "#B6BCC2",
-    orange_dm  = "#E27456",
+    orange_dm  = "#D76558",
     pink_dm    = "#C9709E",
 
     comment    = "#7F848E",
@@ -72,7 +72,7 @@ function M.init()
 
   util.bg = colors.bg
 
-  colors.bg_alt = "#D5DADE" -- "#DBDFE2"
+  colors.bg_alt = "#D8D8D8" -- "#DBDFE2"
   colors.bg_highlight = util.darken(colors.bg, 0.90, "#000000")
 
   colors.fg_alt = util.lighten(colors.fg, 0.85, "#ffffff")

--- a/lua/nightfox/theme.lua
+++ b/lua/nightfox/theme.lua
@@ -11,6 +11,11 @@ function M.apply(colors, config)
   theme.colors = colors
   theme.name = colors.meta.name
   local c = theme.colors
+  local light = c.meta.light
+
+  -- Depending if this colorscheme is light or dark I want either bright or dim modes.
+  local alt_orange = light and c.orange_dm or c.orange_br
+  local alt_magenta = light and c.magenta_dm or c.magenta_br
 
   theme.groups = {
     Comment = { fg = c.comment, style = config.styles.comments }, -- any comment
@@ -83,17 +88,17 @@ function M.apply(colors, config)
     Constant = { fg = c.orange }, -- (preferred) any constant
     String = { fg = c.green, style = config.styles.strings }, --   a string constant: "this is a string"
     Character = { fg = c.green }, --  a character constant: 'c', '\n'
-    Number = { fg = c.orange_br }, --   a number constant: 234, 0xff
-    Float = { fg = c.orange_br }, --    a floating point constant: 2.3e10
-    Boolean = { fg = c.orange_br }, --  a boolean constant: TRUE, false
+    Number = { fg = alt_orange }, --   a number constant: 234, 0xff
+    Float = { fg = alt_orange }, --    a floating point constant: 2.3e10
+    Boolean = { fg = alt_orange }, --  a boolean constant: TRUE, false
 
     Identifier = { fg = c.cyan, style = config.styles.variables }, -- (preferred) any variable name
     Function = { fg = c.blue, style = config.styles.functions }, -- function name (also: methods for classes)
 
-    Statement = { fg = c.magenta_br }, -- (preferred) any statement
-    Conditional = { fg = c.magenta_br }, --  if, then, else, endif, switch, etc.
-    Repeat = { fg = c.magenta_br }, --   for, do, while, etc.
-    Label = { fg = c.magenta_br }, --    case, default, etc.
+    Statement = { fg = alt_magenta }, -- (preferred) any statement
+    Conditional = { fg = alt_magenta }, --  if, then, else, endif, switch, etc.
+    Repeat = { fg = alt_magenta }, --   for, do, while, etc.
+    Label = { fg = alt_magenta }, --    case, default, etc.
     Operator = { fg = c.fg_alt }, -- "sizeof", "+", "*", etc.
     Keyword = { fg = c.magenta, style = config.styles.keywords }, --  any other keyword
     -- Exception     = { }, --  try, catch, throw
@@ -223,7 +228,7 @@ function M.apply(colors, config)
     TSConstructor = { fg = c.magenta }, -- For constructor calls and definitions: `= { }` in Lua, and Java constructors.
     -- TSConditional       = { };    -- For keywords related to conditionnals.
     TSConstant = { fg = c.orange }, -- For constants
-    TSConstBuiltin = { fg = c.orange_br }, -- For constant that are built in the language: `nil` in Lua.
+    TSConstBuiltin = { fg = alt_orange }, -- For constant that are built in the language: `nil` in Lua.
     -- TSConstMacro        = { };    -- For constants that are defined by macros: `NULL` in C.
     -- TSError             = { };    -- For syntax/parser errors.
     -- TSException         = { };    -- For exception related keywords.
@@ -242,7 +247,7 @@ function M.apply(colors, config)
     -- TSNone              = { };    -- TODO: docs
     -- TSNumber            = { };    -- For all numbers
     TSOperator = { fg = c.fg_alt }, -- For any operator: `+`, but also `->` and `*` in C.
-    TSParameter = { fg = c.orange_br }, -- For parameters of a function.
+    TSParameter = { fg = alt_orange }, -- For parameters of a function.
     -- TSParameterReference= { };    -- For references to parameters of a function.
     TSProperty = { fg = c.green }, -- Same as `TSField`.
     tomlTSProperty = { fg = c.blue }, -- Differentiates between string and properties


### PR DESCRIPTION
This change updates dayfox's colors to help with readability. The list
of changes to achive this are as follows:

- Darken the bg color and make the white color uniform in rgb space
- Darken colors to make them more visible. The colors that changed are:
  - red
  - yellow
  - cyan
  - orange

With regards to readability the two colors that are the worst culprits
are `yellow` and `orange`.

In the theme file there are some colors set to bright variants. Now
depending on the background color these will either be bright for dark
or dim for light.

Closes: #47