### PR TITLE
cmp highlight support

### DIFF
--- a/lua/nightfox/theme.lua
+++ b/lua/nightfox/theme.lua
@@ -445,8 +445,8 @@ function M.apply(colors, config)
 
     CmpItemAbbrDeprecated = { fg = c.comment, style = "strikethrough" },
 
-    CmpItemAbbrMatch = { fg = c.blue, style = "bold" },
-    CmpItemAbbrMatchFuzzy = { fg = c.blue, style = "bold" },
+    CmpItemAbbrMatch = { fg = c.blue },
+    CmpItemAbbrMatchFuzzy = { fg = c.blue },
 
     CmpItemKindVariable = { fg = c.cyan },
     CmpItemKindInterface = { fg = c.cyan },

--- a/lua/nightfox/theme.lua
+++ b/lua/nightfox/theme.lua
@@ -448,13 +448,14 @@ function M.apply(colors, config)
     CmpItemKindVariable = { fg = c.cyan },
     CmpItemKindInterface = { fg = c.cyan },
 
-    CmpItemKindFunction = { fg = c.pink },
-    CmpItemKindMethod = { fg = c.pink },
+    CmpItemKindFunction = { fg = c.blue },
+    CmpItemKindMethod = { fg = c.blue },
 
     CmpItemKindText = { fg = c.fg },
     CmpItemKindKeyword = { fg = c.magenta },
     CmpItemKindUnit = { fg = c.magenta },
     CmpItemKindProperty = { fg = c.green },
+    CmpItemKindField = { fg = c.green },
 
     CmpItemKindClass = { fg = c.yellow },
     CmpItemKindModule = { fg = c.yellow },

--- a/lua/nightfox/theme.lua
+++ b/lua/nightfox/theme.lua
@@ -440,6 +440,9 @@ function M.apply(colors, config)
     LightspeedGreyWash = { fg = c.comment },
 
     -- cmp
+    CmpItemKindAbbr = { fg = c.fg },
+    CmpItemKindDefault = { fg = c.fg_alt },
+
     CmpItemAbbrDeprecated = { fg = c.comment, style = "strikethrough" },
 
     CmpItemAbbrMatch = { fg = c.blue, style = "bold" },

--- a/lua/nightfox/theme.lua
+++ b/lua/nightfox/theme.lua
@@ -438,6 +438,26 @@ function M.apply(colors, config)
     FocusedSymbol = { bg = c.bg_search },
 
     LightspeedGreyWash = { fg = c.comment },
+
+    -- cmp
+    CmpItemAbbrDeprecated = { fg = c.comment, style = "strikethrough" },
+
+    CmpItemAbbrMatch = { fg = c.blue, style = "bold" },
+    CmpItemAbbrMatchFuzzy = { fg = c.blue, style = "bold" },
+
+    CmpItemKindVariable = { fg = c.cyan },
+    CmpItemKindInterface = { fg = c.cyan },
+
+    CmpItemKindFunction = { fg = c.pink },
+    CmpItemKindMethod = { fg = c.pink },
+
+    CmpItemKindText = { fg = c.fg },
+    CmpItemKindKeyword = { fg = c.magenta },
+    CmpItemKindUnit = { fg = c.magenta },
+    CmpItemKindProperty = { fg = c.green },
+
+    CmpItemKindClass = { fg = c.yellow },
+    CmpItemKindModule = { fg = c.yellow },
   }
 
   return theme


### PR DESCRIPTION
This PR adds support for new highlight groups introduced in cmp: https://github.com/hrsh7th/nvim-cmp#highlights

Example:

![image](https://user-images.githubusercontent.com/22270/143958342-233f7e86-f5a9-4ab5-b68e-382bae6d6de4.png)
