### PR TITLE
feat: support Lightline for Vim

### DIFF
--- a/autoload/lightline/colorscheme/nightfox.vim
+++ b/autoload/lightline/colorscheme/nightfox.vim
@@ -1,2 +1,9 @@
-let s:palette = v:lua.require('lightline.colorscheme.nightfox')
+if (has('nvim'))
+  let s:palette = v:lua.require('lightline.colorscheme.nightfox')
+else
+  lua nightfox_vim = require"lightline.colorscheme.nightfox_vim"
+  let s:palette_str = luaeval('nightfox_vim')
+  let s:palette = eval(s:palette_str)
+endif
 let g:lightline#colorscheme#nightfox#palette = lightline#colorscheme#fill(s:palette)
+

--- a/lua/lightline/colorscheme/nightfox_vim.lua
+++ b/lua/lightline/colorscheme/nightfox_vim.lua
@@ -1,0 +1,48 @@
+local nf_table = require"lightline.colorscheme.nightfox"
+
+function dump(obj)
+  if type(obj) ~= 'table' then
+    return "'" .. tostring(obj) .. "'"
+  end
+
+  local i = 0
+  local ret = ''
+  local is_arr = 0
+  for k,v in pairs(obj) do
+    if type(k) ~= 'number' then
+      -- the `obj` is a dict
+      if i == 0 then
+        -- first item
+        ret = '{'
+      else
+        ret = ret .. ', '
+      end
+
+      -- wrap the key with single quotes
+      k = "'" .. k .. "'"
+      ret = ret .. k .. ': ' .. dump(v)
+    else
+      -- the `obj` is an array
+      if i == 0 then
+        -- first item
+        ret = '['
+        is_arr = 1
+      else
+        ret = ret .. ', '
+      end
+
+      ret = ret .. dump(v)
+    end
+
+    i = i + 1
+  end
+
+  if is_arr == 0 then
+    return ret .. '}'
+  else
+    return ret .. ']'
+  end
+end
+
+return dump(nf_table)
+

--- a/lua/nightfox/util.lua
+++ b/lua/nightfox/util.lua
@@ -217,6 +217,20 @@ function util.terminal(theme)
   vim.g.terminal_color_13 = theme.colors.magenta_br
   vim.g.terminal_color_14 = theme.colors.cyan_br
   vim.g.terminal_color_15 = theme.colors.white_br
+
+  if (vim.fn.has('nvim') == 0) then
+    local colors = {
+      theme.colors.black, theme.colors.red,
+      theme.colors.green, theme.colors.yellow,
+      theme.colors.blue, theme.colors.magenta,
+      theme.colors.cyan, theme.colors.white,
+      theme.colors.black_br, theme.colors.red_br,
+      theme.colors.green_br, theme.colors.yellow_br,
+      theme.colors.blue_br, theme.colors.magenta_br,
+      theme.colors.cyan_br, theme.colors.white_br
+    }
+    vim.g.terminal_ansi_colors = vim.list(colors)
+  end
 end
 
 function util.load(theme, exec_autocmd)


### PR DESCRIPTION
The original `nightfox` only supports `LightLine` on Neovim, because Vim doesn't has `v:lua.require()`. Therefore, I use `luaeval()` function to load the color table and support `Lightline` on Vim.