### PR TITLE
[Nvim-Tree] Configure a transparent background if 'transparent' is set

### DIFF
--- a/lua/nightfox/theme.lua
+++ b/lua/nightfox/theme.lua
@@ -325,7 +325,7 @@ function M.apply(colors, config)
     TelescopeMatching = { fg = c.blue },
 
     -- NvimTree
-    NvimTreeNormal = { fg = c.fg_sidebar, bg = c.bg_sidebar },
+    NvimTreeNormal = { fg = c.fg_sidebar, bg = config.transparent and c.none or c.bg_sidebar },
     NvimTreeFolderIcon = { fg = c.comment },
     NvimTreeRootFolder = { fg = c.orange, style = "bold" },
     NvimTreeSymlink = { fg = c.magenta },


### PR DESCRIPTION
Currently, if the transparent option is set, Nvim Tree will still use
the solid background color configured in the colors table. As it stands
there is no way to make so that the side window matches the transparency
of the main window.

This change proposes a change targeted only to NvimTree. If accepted
this approach could be use more generally by replacing the c.bg_sidebar
with none and not having to check each time bg_sidebar is used.