### PR TITLE
feat(modules): Add modes.nvim support

### DIFF
--- a/doc/nightfox.txt
+++ b/doc/nightfox.txt
@@ -352,17 +352,12 @@ A `group` is the definition of a `highlight-group`. The key of the group table
 is the `highlight-group` that will be defined, and the table value is the
 arguments to the |:highlight| command.
 
-│ Key │     Help     │                     Description                     │
-│fg   │|highlight-gui│The color value of the foreground of the highlight gr│
-│     │fg|           │oup                                                  │
-│bg   │|highlight-gui│The color value of the background of the highlight gr│
-│     │bg|           │oup                                                  │
-│sp   │|highlight-gui│The color for underlines and undercurls              │
-│     │sp|           │                                                     │
-│style│|highlight-gui│The style of the highlight group. Ex italic, bold, et│
-│     │|             │c                                                    │
-│link │|highlight-lin│Link one highlight-group to another                  │
-│     │k|            │                                                     │
+│ Key │      Help       │                         Description                          │
+│fg   │|highlight-guifg|│The color value of the foreground of the highlight group      │
+│bg   │|highlight-guibg|│The color value of the background of the highlight group      │
+│sp   │|highlight-guisp|│The color for underlines and undercurls                       │
+│style│|highlight-gui|  │The style of the highlight group. Ex italic, bold, etc        │
+│link │|highlight-link| │Link one highlight-group to another                           │
 
 
 If the value of `link` is present and is not empty, nightfox will link the
@@ -395,6 +390,7 @@ Current list of modules are:
 - lightspeed
 - lsp_saga
 - lsp_trouble
+- modes
 - native_lsp
 - neogit
 - nvimtree

--- a/lua/nightfox/config.lua
+++ b/lua/nightfox/config.lua
@@ -41,6 +41,7 @@ M.options = {
     lightspeed = true,
     lsp_saga = true,
     lsp_trouble = true,
+    modes = true,
     native_lsp = true,
     neogit = true,
     nvimtree = true,

--- a/lua/nightfox/group/modules/modes.lua
+++ b/lua/nightfox/group/modules/modes.lua
@@ -1,0 +1,17 @@
+-- https://github.com/mvllow/modes.nvim
+
+local M = {}
+
+function M.get(spec, config, opts)
+  local pal = spec.pallet
+
+  -- stylua: ignore
+  return {
+    ModesCopy   = { bg = pal.yellow.base },
+    ModesDelete = { bg = pal.red.base },
+    ModesInsert = { bg = pal.cyan.base },
+    ModesVisual = { bg = pal.magenta.base },
+  }
+end
+
+return M

--- a/lua/nightfox/precompiled/dawnfox_compiled.lua
+++ b/lua/nightfox/precompiled/dawnfox_compiled.lua
@@ -118,6 +118,10 @@ highlight LspTroubleNormal guifg=#a8a3b3 guibg=#ebe5df gui=NONE guisp=NONE |
 highlight LspTroubleText guifg=#625c87 guibg=NONE gui=NONE guisp=NONE |
 highlight MatchParen guifg=#ea9d34 guibg=NONE gui=bold guisp=NONE |
 highlight ModeMsg guifg=#ea9d34 guibg=NONE gui=bold guisp=NONE |
+highlight ModesCopy guifg=NONE guibg=#ea9d34 gui=NONE guisp=NONE |
+highlight ModesDelete guifg=NONE guibg=#b4637a gui=NONE guisp=NONE |
+highlight ModesInsert guifg=NONE guibg=#56949f gui=NONE guisp=NONE |
+highlight ModesVisual guifg=NONE guibg=#907aa9 gui=NONE guisp=NONE |
 highlight MoreMsg guifg=#286983 guibg=NONE gui=bold guisp=NONE |
 highlight MsgArea guifg=#625c87 guibg=NONE gui=NONE guisp=NONE |
 highlight NeogitBranch guifg=#ea9d34 guibg=NONE gui=NONE guisp=NONE |

--- a/lua/nightfox/precompiled/dayfox_compiled.lua
+++ b/lua/nightfox/precompiled/dayfox_compiled.lua
@@ -118,6 +118,10 @@ highlight LspTroubleNormal guifg=#2e537d guibg=#dbdbdb gui=NONE guisp=NONE |
 highlight LspTroubleText guifg=#233f5e guibg=NONE gui=NONE guisp=NONE |
 highlight MatchParen guifg=#ba793e guibg=NONE gui=bold guisp=NONE |
 highlight ModeMsg guifg=#ba793e guibg=NONE gui=bold guisp=NONE |
+highlight ModesCopy guifg=NONE guibg=#ba793e gui=NONE guisp=NONE |
+highlight ModesDelete guifg=NONE guibg=#b95d76 gui=NONE guisp=NONE |
+highlight ModesInsert guifg=NONE guibg=#6ca7bd gui=NONE guisp=NONE |
+highlight ModesVisual guifg=NONE guibg=#8e6f98 gui=NONE guisp=NONE |
 highlight MoreMsg guifg=#4d688e guibg=NONE gui=bold guisp=NONE |
 highlight MsgArea guifg=#233f5e guibg=NONE gui=NONE guisp=NONE |
 highlight NeogitBranch guifg=#ba793e guibg=NONE gui=NONE guisp=NONE |

--- a/lua/nightfox/precompiled/duskfox_compiled.lua
+++ b/lua/nightfox/precompiled/duskfox_compiled.lua
@@ -118,6 +118,10 @@ highlight LspTroubleNormal guifg=#555169 guibg=#191726 gui=NONE guisp=NONE |
 highlight LspTroubleText guifg=#d3d1e6 guibg=NONE gui=NONE guisp=NONE |
 highlight MatchParen guifg=#f6c177 guibg=NONE gui=bold guisp=NONE |
 highlight ModeMsg guifg=#f6c177 guibg=NONE gui=bold guisp=NONE |
+highlight ModesCopy guifg=NONE guibg=#f6c177 gui=NONE guisp=NONE |
+highlight ModesDelete guifg=NONE guibg=#eb6f92 gui=NONE guisp=NONE |
+highlight ModesInsert guifg=NONE guibg=#9ccfd8 gui=NONE guisp=NONE |
+highlight ModesVisual guifg=NONE guibg=#c4a7e7 gui=NONE guisp=NONE |
 highlight MoreMsg guifg=#569fba guibg=NONE gui=bold guisp=NONE |
 highlight MsgArea guifg=#d3d1e6 guibg=NONE gui=NONE guisp=NONE |
 highlight NeogitBranch guifg=#f6c177 guibg=NONE gui=NONE guisp=NONE |

--- a/lua/nightfox/precompiled/nightfox_compiled.lua
+++ b/lua/nightfox/precompiled/nightfox_compiled.lua
@@ -118,6 +118,10 @@ highlight LspTroubleNormal guifg=#71839b guibg=#131a24 gui=NONE guisp=NONE |
 highlight LspTroubleText guifg=#aeafb0 guibg=NONE gui=NONE guisp=NONE |
 highlight MatchParen guifg=#dbc074 guibg=NONE gui=bold guisp=NONE |
 highlight ModeMsg guifg=#dbc074 guibg=NONE gui=bold guisp=NONE |
+highlight ModesCopy guifg=NONE guibg=#dbc074 gui=NONE guisp=NONE |
+highlight ModesDelete guifg=NONE guibg=#c94f6d gui=NONE guisp=NONE |
+highlight ModesInsert guifg=NONE guibg=#63cdcf gui=NONE guisp=NONE |
+highlight ModesVisual guifg=NONE guibg=#9d79d6 gui=NONE guisp=NONE |
 highlight MoreMsg guifg=#719cd6 guibg=NONE gui=bold guisp=NONE |
 highlight MsgArea guifg=#aeafb0 guibg=NONE gui=NONE guisp=NONE |
 highlight NeogitBranch guifg=#dbc074 guibg=NONE gui=NONE guisp=NONE |

--- a/lua/nightfox/precompiled/nordfox_compiled.lua
+++ b/lua/nightfox/precompiled/nordfox_compiled.lua
@@ -118,6 +118,10 @@ highlight LspTroubleNormal guifg=#7e8188 guibg=#232831 gui=NONE guisp=NONE |
 highlight LspTroubleText guifg=#abb1bb guibg=NONE gui=NONE guisp=NONE |
 highlight MatchParen guifg=#ebcb8b guibg=NONE gui=bold guisp=NONE |
 highlight ModeMsg guifg=#ebcb8b guibg=NONE gui=bold guisp=NONE |
+highlight ModesCopy guifg=NONE guibg=#ebcb8b gui=NONE guisp=NONE |
+highlight ModesDelete guifg=NONE guibg=#bf616a gui=NONE guisp=NONE |
+highlight ModesInsert guifg=NONE guibg=#88c0d0 gui=NONE guisp=NONE |
+highlight ModesVisual guifg=NONE guibg=#b48ead gui=NONE guisp=NONE |
 highlight MoreMsg guifg=#81a1c1 guibg=NONE gui=bold guisp=NONE |
 highlight MsgArea guifg=#abb1bb guibg=NONE gui=NONE guisp=NONE |
 highlight NeogitBranch guifg=#ebcb8b guibg=NONE gui=NONE guisp=NONE |

--- a/readme.md
+++ b/readme.md
@@ -371,6 +371,7 @@ Nightfox provides the following commands that wrap these functions above:
 - [lightspeed.nvim](https://github.com/ggandor/lightspeed.nvim)
 - [lspsaga.nvim](https://github.com/glepnir/lspsaga.nvim)
 - [lsp-trouble.nvim](https://github.com/simrat39/lsp-trouble.nvim)
+- [modes.nvim](https://github.com/mvllow/modes.nvim)
 - [neogit](https://github.com/TimUntersberger/neogit)
 - [nvim-tree.lua](https://github.com/kyazdani42/nvim-tree.lua)
 - [vim-sneak](https://github.com/justinmk/vim-sneak)

--- a/usage.md
+++ b/usage.md
@@ -303,6 +303,7 @@ Current list of modules are:
 - lightspeed
 - lsp_saga
 - lsp_trouble
+- modes
 - native_lsp
 - neogit
 - nvimtree


### PR DESCRIPTION
This Pr adds support for [modes.nvim](https://github.com/mvllow/modes.nvim)

I tried to add support using nightfox's colors with bg values but had issues with modes.nvim as it was very buggy at the moment of implementation. I am having a hard time getting the statusline to co-operate. I am using this `minimal_init.lua` for testing:

```lua
-- `minimal_init.lua` used for reproducing neovim issues
-- Open with `nvim --clean -u minimal_init.lua`

local root_tmp = vim.fn.has("win32") == 1 and os.getenv("TEMP") or "/tmp"
local install_path = root_tmp .. "/nvim/site/pack/packer/start/packer.nvim"
local compile_path = install_path .. "/plugin/packer_compiled.lua"
vim.opt.packpath = "/tmp/nvim/site"

local function load_plugins()
  local packer = require("packer")
  local use = packer.use
  packer.reset()
  packer.init({ compile_path = compile_path, package_root = root_tmp .. "/nvim/site/pack" })

  use("wbthomason/packer.nvim")
  use("~/dev/plugins/nightfox.nvim")
  use("mvllow/modes.nvim")

  -- ADD PLUGINS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE

  packer.sync()
end

_G.load_config = function()
  -- ADD INIT.LUA SETTINGS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
  vim.o.cursorline = true
  require("modes").setup()
  vim.cmd("colorscheme nightfox")
end

if vim.fn.isdirectory(install_path) == 0 then
  vim.fn.system({ "git", "clone", "--depth=1", "https://github.com/wbthomason/packer.nvim", install_path })
end
load_plugins()
vim.cmd([[autocmd User PackerComplete ++once echo "Ready!" | lua load_config()]])
```


Resolves #75 