### PR TITLE
fix(lib): `highlight` takes inverse for nvim api call

### DIFF
--- a/lua/nightfox/lib/highlight.lua
+++ b/lua/nightfox/lib/highlight.lua
@@ -73,6 +73,7 @@ local function nvim_hl(highlights)
         italic = style.italic,
         underline = style.underline,
         undercurl = style.undercurl,
+        reverse = style.inverse,
       })
     end
   end


### PR DESCRIPTION
Resolves: #79 