### PR TITLE
Feat: Add lualine theme for dawnfox

### DIFF
--- a/lua/lualine/themes/dawnfox.lua
+++ b/lua/lualine/themes/dawnfox.lua
@@ -1,0 +1,37 @@
+local colors = require("nightfox.colors").load()
+
+local nightfox = {}
+
+nightfox.normal = {
+  a = { bg = colors.blue_br, fg = colors.white },
+  b = { bg = colors.white_dm, fg = colors.blue_br },
+  c = { bg = colors.bg_statusline, fg = colors.fg_sidebar },
+}
+
+nightfox.insert = {
+  a = { bg = colors.green, fg = colors.white },
+  b = { bg = colors.white, fg = colors.green },
+}
+
+nightfox.command = {
+  a = { bg = colors.yellow, fg = colors.black },
+  b = { bg = colors.white_dm, fg = colors.yellow_dm },
+}
+
+nightfox.visual = {
+  a = { bg = colors.magenta, fg = colors.white },
+  b = { bg = colors.white_dm, fg = colors.magenta },
+}
+
+nightfox.replace = {
+  a = { bg = colors.red, fg = colors.white },
+  b = { bg = colors.white_dm, fg = colors.red },
+}
+
+nightfox.inactive = {
+  a = { bg = colors.bg_statusline, fg = colors.blue },
+  b = { bg = colors.bg_statusline, fg = colors.white_dm, gui = "bold" },
+  c = { bg = colors.bg_statusline, fg = colors.white_dm },
+}
+
+return nightfox


### PR DESCRIPTION
The lualine theme only has one for `nightfox`. And the rest of themes doesn't have such.
So, if you are using colorscheme other than nightfox, the lualine will auto generate the theme for it.
And the theme auto-generated by lualine isn't that appealing: especially the "normal mode" icon doesn't have a good hightlight.
So by referencing the setting for `nightfox.lua` in the themes folder, (adjusting some visual elements so that it fits a light theme better), I create the lualine theme for dawnfox.lua.
