### PR TITLE
fix(lualine): Define theme for each style

### DIFF
--- a/lua/lualine/themes/dawnfox.lua
+++ b/lua/lualine/themes/dawnfox.lua
@@ -1,5 +1,5 @@
 local Color = require("nightfox.lib.color")
-local spec = require("nightfox.spec").load("nightfox")
+local spec = require("nightfox.spec").load("dawnfox")
 
 local pal = spec.pallet
 local bg = Color.from_hex(spec.bg0)

--- a/lua/lualine/themes/dayfox.lua
+++ b/lua/lualine/themes/dayfox.lua
@@ -1,5 +1,5 @@
 local Color = require("nightfox.lib.color")
-local spec = require("nightfox.spec").load("nightfox")
+local spec = require("nightfox.spec").load("dayfox")
 
 local pal = spec.pallet
 local bg = Color.from_hex(spec.bg0)

--- a/lua/lualine/themes/duskfox.lua
+++ b/lua/lualine/themes/duskfox.lua
@@ -1,5 +1,5 @@
 local Color = require("nightfox.lib.color")
-local spec = require("nightfox.spec").load("nightfox")
+local spec = require("nightfox.spec").load("duskfox")
 
 local pal = spec.pallet
 local bg = Color.from_hex(spec.bg0)

--- a/lua/lualine/themes/nordfox.lua
+++ b/lua/lualine/themes/nordfox.lua
@@ -1,5 +1,5 @@
 local Color = require("nightfox.lib.color")
-local spec = require("nightfox.spec").load("nightfox")
+local spec = require("nightfox.spec").load("nordfox")
 
 local pal = spec.pallet
 local bg = Color.from_hex(spec.bg0)

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ Plug 'EdenEast/nightfox.nvim', { 'tag': 'v1.0.0' } " Vim-Plug
 <summary>Color Migration table</summary>
 
 | V1 color     | V2 pallet |
-|--------------|-----------|
+| ------------ | --------- |
 | bg           | bg1       |
 | bg_alt       | bg0       |
 | bg_sidebar   | bg0       |
@@ -381,16 +381,14 @@ Nightfox provides the following commands that wrap these functions above:
 
 ## Status lines
 
-**Note:** For all status lines `nightfox` is the only valid name.
-
 ### [Lualine]
 
+Lualine checks the value of `vim.g.colors_name` (set when using `:colorscheme` command) to determine the theme to load.
+Set your colorscheme before calling setup.
+
 ```lua
-require('lualine').setup({
-  options = {
-    theme = "nightfox"
-  }
-})
+vim.cmd("colorscheme nightfox")
+require('lualine').setup({ ... })
 ```
 
 ## Extra


### PR DESCRIPTION
Lualine checks the value of `vim.g.colors_name` to load the appropriate
theme file. This change defines a lua theme foreach style.

Note: colorscheme should be set before calling lualine.setup()
so that `vim.g.colors_name` is set.

Resolve: #83 