### PR TITLE
fix(group): Swap link of `CursorLine` and `CursorColumn`

### DIFF
--- a/lua/nightfox/group/editor.lua
+++ b/lua/nightfox/group/editor.lua
@@ -12,8 +12,8 @@ function M.get(spec, config)
     Cursor          = { fg = spec.bg1, bg = spec.fg1 }, -- character under the cursor
     lCursor         = { link = "Cursor" }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
     CursorIM        = { link = "Cursor" }, -- like Cursor, but used when in IME mode |CursorIM|
-    CursorColumn    = { bg = spec.bg3 }, -- Screen-column at the cursor, when 'cursorcolumn' is set.
-    CursorLine      = { link = "CursorColumn" }, -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
+    CursorColumn    = { link = "CursorLine" }, -- Screen-column at the cursor, when 'cursorcolumn' is set.
+    CursorLine      = { bg = spec.bg3 }, -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
     Directory       = { fg = spec.syntax.func }, -- directory names (and other special names in listings)
     DiffAdd         = { bg = spec.diff.add }, -- diff mode: Added line |diff.txt|
     DiffChange      = { bg = spec.diff.change }, -- diff mode: Changed line |diff.txt|

--- a/lua/nightfox/precompiled/dawnfox_compiled.lua
+++ b/lua/nightfox/precompiled/dawnfox_compiled.lua
@@ -39,7 +39,7 @@ highlight Conceal guifg=#bdbfc9 guibg=NONE gui=NONE guisp=NONE |
 highlight Conditional guifg=#816b9a guibg=NONE gui=NONE guisp=NONE |
 highlight Constant guifg=#ca6e69 guibg=NONE gui=NONE guisp=NONE |
 highlight Cursor guifg=#faf4ed guibg=#575279 gui=NONE guisp=NONE |
-highlight CursorColumn guifg=NONE guibg=#ebdfe4 gui=NONE guisp=NONE |
+highlight CursorLine guifg=NONE guibg=#ebdfe4 gui=NONE guisp=NONE |
 highlight CursorLineNr guifg=#ea9d34 guibg=NONE gui=bold guisp=NONE |
 highlight DashboardFooter guifg=#ca6e69 guibg=NONE gui=italic guisp=NONE |
 highlight DiagnosticError guifg=#b4637a guibg=NONE gui=NONE guisp=NONE |
@@ -256,8 +256,8 @@ highlight! link CmpItemKindUnit Constant |
 highlight! link CmpItemKindValue Keyword |
 highlight! link CmpItemKindVariable TSVariable |
 highlight! link CmpItemMenu Comment |
+highlight! link CursorColumn CursorLine |
 highlight! link CursorIM Cursor |
-highlight! link CursorLine CursorColumn |
 highlight! link DashboardCenter String |
 highlight! link DashboardHeader Title |
 highlight! link DashboardShortCut Identifier |

--- a/lua/nightfox/precompiled/dayfox_compiled.lua
+++ b/lua/nightfox/precompiled/dayfox_compiled.lua
@@ -39,7 +39,7 @@ highlight Conceal guifg=#bebebe guibg=NONE gui=NONE guisp=NONE |
 highlight Conditional guifg=#806589 guibg=NONE gui=NONE guisp=NONE |
 highlight Constant guifg=#d76558 guibg=NONE gui=NONE guisp=NONE |
 highlight Cursor guifg=#eaeaea guibg=#1d344f gui=NONE guisp=NONE |
-highlight CursorColumn guifg=NONE guibg=#ced6db gui=NONE guisp=NONE |
+highlight CursorLine guifg=NONE guibg=#ced6db gui=NONE guisp=NONE |
 highlight CursorLineNr guifg=#ba793e guibg=NONE gui=bold guisp=NONE |
 highlight DashboardFooter guifg=#d76558 guibg=NONE gui=italic guisp=NONE |
 highlight DiagnosticError guifg=#b95d76 guibg=NONE gui=NONE guisp=NONE |
@@ -256,8 +256,8 @@ highlight! link CmpItemKindUnit Constant |
 highlight! link CmpItemKindValue Keyword |
 highlight! link CmpItemKindVariable TSVariable |
 highlight! link CmpItemMenu Comment |
+highlight! link CursorColumn CursorLine |
 highlight! link CursorIM Cursor |
-highlight! link CursorLine CursorColumn |
 highlight! link DashboardCenter String |
 highlight! link DashboardHeader Title |
 highlight! link DashboardShortCut Identifier |

--- a/lua/nightfox/precompiled/duskfox_compiled.lua
+++ b/lua/nightfox/precompiled/duskfox_compiled.lua
@@ -39,7 +39,7 @@ highlight Conceal guifg=#4b4673 guibg=NONE gui=NONE guisp=NONE |
 highlight Conditional guifg=#ccb1ed guibg=NONE gui=NONE guisp=NONE |
 highlight Constant guifg=#f0a4a2 guibg=NONE gui=NONE guisp=NONE |
 highlight Cursor guifg=#232136 guibg=#e0def4 gui=NONE guisp=NONE |
-highlight CursorColumn guifg=NONE guibg=#373354 gui=NONE guisp=NONE |
+highlight CursorLine guifg=NONE guibg=#373354 gui=NONE guisp=NONE |
 highlight CursorLineNr guifg=#f6c177 guibg=NONE gui=bold guisp=NONE |
 highlight DashboardFooter guifg=#f0a4a2 guibg=NONE gui=italic guisp=NONE |
 highlight DiagnosticError guifg=#eb6f92 guibg=NONE gui=NONE guisp=NONE |
@@ -256,8 +256,8 @@ highlight! link CmpItemKindUnit Constant |
 highlight! link CmpItemKindValue Keyword |
 highlight! link CmpItemKindVariable TSVariable |
 highlight! link CmpItemMenu Comment |
+highlight! link CursorColumn CursorLine |
 highlight! link CursorIM Cursor |
-highlight! link CursorLine CursorColumn |
 highlight! link DashboardCenter String |
 highlight! link DashboardHeader Title |
 highlight! link DashboardShortCut Identifier |

--- a/lua/nightfox/precompiled/nightfox_compiled.lua
+++ b/lua/nightfox/precompiled/nightfox_compiled.lua
@@ -39,7 +39,7 @@ highlight Conceal guifg=#415166 guibg=NONE gui=NONE guisp=NONE |
 highlight Conditional guifg=#baa1e2 guibg=NONE gui=NONE guisp=NONE |
 highlight Constant guifg=#f6b079 guibg=NONE gui=NONE guisp=NONE |
 highlight Cursor guifg=#192330 guibg=#cdcecf gui=NONE guisp=NONE |
-highlight CursorColumn guifg=NONE guibg=#29394e gui=NONE guisp=NONE |
+highlight CursorLine guifg=NONE guibg=#29394e gui=NONE guisp=NONE |
 highlight CursorLineNr guifg=#dbc074 guibg=NONE gui=bold guisp=NONE |
 highlight DashboardFooter guifg=#f6b079 guibg=NONE gui=italic guisp=NONE |
 highlight DiagnosticError guifg=#c94f6d guibg=NONE gui=NONE guisp=NONE |
@@ -256,8 +256,8 @@ highlight! link CmpItemKindUnit Constant |
 highlight! link CmpItemKindValue Keyword |
 highlight! link CmpItemKindVariable TSVariable |
 highlight! link CmpItemMenu Comment |
+highlight! link CursorColumn CursorLine |
 highlight! link CursorIM Cursor |
-highlight! link CursorLine CursorColumn |
 highlight! link DashboardCenter String |
 highlight! link DashboardHeader Title |
 highlight! link DashboardShortCut Identifier |

--- a/lua/nightfox/precompiled/nordfox_compiled.lua
+++ b/lua/nightfox/precompiled/nordfox_compiled.lua
@@ -39,7 +39,7 @@ highlight Conceal guifg=#5a657d guibg=NONE gui=NONE guisp=NONE |
 highlight Conditional guifg=#c895bf guibg=NONE gui=NONE guisp=NONE |
 highlight Constant guifg=#d89079 guibg=NONE gui=NONE guisp=NONE |
 highlight Cursor guifg=#2e3440 guibg=#cdcecf gui=NONE guisp=NONE |
-highlight CursorColumn guifg=NONE guibg=#444c5e gui=NONE guisp=NONE |
+highlight CursorLine guifg=NONE guibg=#444c5e gui=NONE guisp=NONE |
 highlight CursorLineNr guifg=#ebcb8b guibg=NONE gui=bold guisp=NONE |
 highlight DashboardFooter guifg=#d89079 guibg=NONE gui=italic guisp=NONE |
 highlight DiagnosticError guifg=#bf616a guibg=NONE gui=NONE guisp=NONE |
@@ -256,8 +256,8 @@ highlight! link CmpItemKindUnit Constant |
 highlight! link CmpItemKindValue Keyword |
 highlight! link CmpItemKindVariable TSVariable |
 highlight! link CmpItemMenu Comment |
+highlight! link CursorColumn CursorLine |
 highlight! link CursorIM Cursor |
-highlight! link CursorLine CursorColumn |
 highlight! link DashboardCenter String |
 highlight! link DashboardHeader Title |
 highlight! link DashboardShortCut Identifier |


### PR DESCRIPTION
CursorLine and CursorColumn should be linked. CursorLine is the more
common setting of the two so should be the one that is defined.

Relates to: #90 