### PR TITLE
Fix typo in ts-rainbow highlight names

### DIFF
--- a/lua/nightfox/group/modules/tsrainbow.lua
+++ b/lua/nightfox/group/modules/tsrainbow.lua
@@ -7,13 +7,13 @@ function M.get(spec, config, opts)
 
   -- stylua: ignore
   return {
-    rainboecol1 = { fg = c.red.base },
-    rainboecol2 = { fg = c.yellow.base },
-    rainboecol3 = { fg = c.green.base },
-    rainboecol4 = { fg = c.blue.base },
-    rainboecol5 = { fg = c.cyan.base },
-    rainboecol6 = { fg = c.magenta.base },
-    rainboecol7 = { fg = c.pink.base },
+    rainbowcol1 = { fg = c.red.base },
+    rainbowcol2 = { fg = c.yellow.base },
+    rainbowcol3 = { fg = c.green.base },
+    rainbowcol4 = { fg = c.blue.base },
+    rainbowcol5 = { fg = c.cyan.base },
+    rainbowcol6 = { fg = c.magenta.base },
+    rainbowcol7 = { fg = c.pink.base },
   }
 end
 


### PR DESCRIPTION
Looks like there's a typo in the ts-rainbow highlight names; I was getting searing red brackets instead of nice nightfox red ones, and the colour order of nested ones didn't match.

I did run `make compile` but it seems to have introduced a bunch of additional changes beyond the `rainboe`/`rainbow` fixes, so I'm not sure if you want that or not, so I've not included it. Happy to do patch-add just the necessary lines if you want, but wanted some guidance since I've not worked on this project before.

```
nightfox.nvim % git st
 M lua/nightfox/precompiled/dawnfox_compiled.lua
 M lua/nightfox/precompiled/dayfox_compiled.lua
 M lua/nightfox/precompiled/duskfox_compiled.lua
 M lua/nightfox/precompiled/nightfox_compiled.lua
 M lua/nightfox/precompiled/nordfox_compiled.lua

nightfox.nvim % git diff | awk '/-highlight/ { print $2 }' | sort | uniq
BufferInactiveMod
DiagnosticVirtualTextError
DiagnosticVirtualTextHint
DiagnosticVirtualTextInfo
DiagnosticVirtualTextWarn
DiffAdd
DiffChange
DiffDelete
DiffText
GlyphPallet8
GlyphPallet9
NeoTreeFileNameOpened
NeoTreeSymbolicLinkTarget
NeogitDiffAddHighlight
NeogitDiffContextHighlight
NeogitDiffDeleteHighlight
NvimTreeOpenedFile
NvimTreeSymlink
PreProc
diffIndexLine
rainboecol1
rainboecol2
rainboecol3
rainboecol4
rainboecol5
rainboecol6
rainboecol7
```