### PR TITLE
Fix typos in doc

### DIFF
--- a/doc/nightfox.txt
+++ b/doc/nightfox.txt
@@ -589,7 +589,7 @@ color:blend({other}, {factor})         Returns a new `Color` that is a linear
 
 color:shade({factor})                  Returns a new `Color` that has been
                                        `shaded` by the {factor}. The factor is
-                                       a precentage from `[0,1]` where `0` is
+                                       a precentage from `[-1,1]` where `-1` is
                                        black and `1` is white.
 
 

--- a/usage.md
+++ b/usage.md
@@ -450,7 +450,7 @@ blending and `1` is entirely the {other} color.
 
 #### color:shade({factor})
 
-Returns a new `Color` that has been `shaded` by the {factor}. The factor is a precentage from `[0,1]` where `0` is black
+Returns a new `Color` that has been `shaded` by the {factor}. The factor is a precentage from `[-1,1]` where `-1` is black
 and `1` is white.
 
 #### color:brighten({value})


### PR DESCRIPTION
During reading the source code of color lib, I noticed the descriptions for `Color:shade()` in both `doc.txt` and `usage.md` are mistyped, the percentage factor should be `[-1, 1]`, not `[0, 1]`. 

Thank you so much for developing this colorscheme plugin, I have been in love with it. 