### PR TITLE
docs(help): Add the range for {value}

### DIFF
--- a/doc/nightfox.txt
+++ b/doc/nightfox.txt
@@ -600,7 +600,7 @@ color:brighten({value})                Returns a new `Color` with {value} added
                                        color. This returns a lighter version of
                                        of the current color if {value} is
                                        positive and a darker color is {value}
-                                       is negative.
+                                       is negative. {value} is Float `[-100, 100]` .
 
 
                                                     *nightfox-color:lighten()*
@@ -610,7 +610,7 @@ color:lighten({value})                 Returns a new `Color` with {value} added
                                        current color. This returns a lighter
                                        version of of the current color if
                                        {value} is positive and a darker color
-                                       is {value} is negative.
+                                       is {value} is negative. {value} is Float `[-100, 100]` .
 
 
                                                    *nightfox-color:saturate()*
@@ -619,7 +619,7 @@ color:saturate({value})                Returns a new `Color` with {value} added
                                        to the `saturation` (`hsv`) of the
                                        current color. This returns either a
                                        more or less saturated version depending
-                                       of +/- v.
+                                       of +/- v. {value} is Float `[-100, 100]` .
 
 
                                                      *nightfox-color:rotate()*

--- a/usage.md
+++ b/usage.md
@@ -456,17 +456,17 @@ and `1` is white.
 #### color:brighten({value})
 
 Returns a new `Color` with {value} added to the `value` (`hsv`) of the current color. This returns a lighter version of
-of the current color if {value} is positive and a darker color is {value} is negative.
+of the current color if {value} is positive and a darker color is {value} is negative. {value} is Float [-100, 100].
 
 #### color:lighten({value})
 
 Returns a new `Color` with {value} added to the `lightness` (`hsl`) of the current color. This returns a lighter version of
-of the current color if {value} is positive and a darker color is {value} is negative.
+of the current color if {value} is positive and a darker color is {value} is negative. {value} is Float [-100, 100].
 
 #### color:saturate({value})
 
 Returns a new `Color` with {value} added to the `saturation` (`hsv`) of the current color. This returns either a more
-or less saturated version depending of +/- v.
+or less saturated version depending of +/- v. {value} is Float [-100, 100].
 
 #### color:rotate({value})
 


### PR DESCRIPTION
I added {value} range for `Color:lighten()`, `Color: brighten()` and `Color: saturate()` that was not mentioned in `doc.txt` and `usage.md`. 

Thanks. 