### PR TITLE
fix(palette): Increase contrast for `duskfox` folds

### DIFF
--- a/extra/duskfox/nightfox_konsole.colorscheme
+++ b/extra/duskfox/nightfox_konsole.colorscheme
@@ -83,7 +83,7 @@ Color=226,224,247
 Color=224,222,244
 
 [ForegroundFaint]
-Color=211,209,230
+Color=205,203,224
 
 [ForegroundIntense]
 Color=234,232,255

--- a/extra/duskfox/nightfox_tmux.tmux
+++ b/extra/duskfox/nightfox_tmux.tmux
@@ -2,10 +2,10 @@
 # Nightfox colors for Tmux
 # Style: duskfox
 # Upstream: https://github.com/edeneast/nightfox.nvim/raw/main/extra/duskfox/nightfox_tmux.tmux
-set -g mode-style "fg=#569fba,bg=#d3d1e6"
-set -g message-style "fg=#569fba,bg=#d3d1e6"
-set -g message-command-style "fg=#569fba,bg=#d3d1e6"
-set -g pane-border-style "fg=#d3d1e6"
+set -g mode-style "fg=#569fba,bg=#cdcbe0"
+set -g message-style "fg=#569fba,bg=#cdcbe0"
+set -g message-command-style "fg=#569fba,bg=#cdcbe0"
+set -g pane-border-style "fg=#cdcbe0"
 set -g pane-active-border-style "fg=#569fba"
 set -g status "on"
 set -g status-justify "left"
@@ -15,9 +15,9 @@ set -g status-right-length "100"
 set -g status-left-style NONE
 set -g status-right-style NONE
 set -g status-left "#[fg=#393552,bg=#569fba,bold] #S #[fg=#569fba,bg=#191726,nobold,nounderscore,noitalics]"
-set -g status-right "#[fg=#191726,bg=#191726,nobold,nounderscore,noitalics]#[fg=#569fba,bg=#191726] #{prefix_highlight} #[fg=#d3d1e6,bg=#191726,nobold,nounderscore,noitalics]#[fg=#569fba,bg=#d3d1e6] %Y-%m-%d  %I:%M %p #[fg=#569fba,bg=#d3d1e6,nobold,nounderscore,noitalics]#[fg=#393552,bg=#569fba,bold] #h "
-setw -g window-status-activity-style "underscore,fg=#555169,bg=#191726"
+set -g status-right "#[fg=#191726,bg=#191726,nobold,nounderscore,noitalics]#[fg=#569fba,bg=#191726] #{prefix_highlight} #[fg=#cdcbe0,bg=#191726,nobold,nounderscore,noitalics]#[fg=#569fba,bg=#cdcbe0] %Y-%m-%d  %I:%M %p #[fg=#569fba,bg=#cdcbe0,nobold,nounderscore,noitalics]#[fg=#393552,bg=#569fba,bold] #h "
+setw -g window-status-activity-style "underscore,fg=#6e6a86,bg=#191726"
 setw -g window-status-separator ""
-setw -g window-status-style "NONE,fg=#555169,bg=#191726"
+setw -g window-status-style "NONE,fg=#6e6a86,bg=#191726"
 setw -g window-status-format "#[fg=#191726,bg=#191726,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#191726,bg=#191726,nobold,nounderscore,noitalics]"
-setw -g window-status-current-format "#[fg=#191726,bg=#d3d1e6,nobold,nounderscore,noitalics]#[fg=#569fba,bg=#d3d1e6,bold] #I  #W #F #[fg=#d3d1e6,bg=#191726,nobold,nounderscore,noitalics]"
+setw -g window-status-current-format "#[fg=#191726,bg=#cdcbe0,nobold,nounderscore,noitalics]#[fg=#569fba,bg=#cdcbe0,bold] #I  #W #F #[fg=#cdcbe0,bg=#191726,nobold,nounderscore,noitalics]"

--- a/lua/nightfox/group/editor.lua
+++ b/lua/nightfox/group/editor.lua
@@ -24,8 +24,8 @@ function M.get(spec, config)
     -- TermCursorNC    = {}, -- cursor in an unfocused terminal
     ErrorMsg        = { fg = spec.diag.error }, -- error messages on the command line
     VertSplit       = { fg = spec.bg4 }, -- the column separating vertically split windows
-    Folded          = { fg = spec.fg3, bg = spec.bg3 }, -- line used for closed folds
-    FoldColumn      = { fg = spec.bg3 }, -- 'foldcolumn'
+    Folded          = { fg = spec.fg3, bg = spec.bg2 }, -- line used for closed folds
+    FoldColumn      = { fg = spec.fg3 }, -- 'foldcolumn'
     SignColumn      = { fg = spec.fg3 }, -- column where |signs| are displayed
     SignColumnSB    = { link = "SignColumn" }, -- column where |signs| are displayed
     Substitute      = { fg = spec.bg1, bg = spec.diag.error }, -- |:substitute| replacement text highlighting

--- a/lua/nightfox/palette/duskfox.lua
+++ b/lua/nightfox/palette/duskfox.lua
@@ -29,8 +29,8 @@ local palette = {
 
   fg0     = "#eae8ff", -- Lighter fg
   fg1     = "#e0def4", -- Default fg
-  fg2     = "#d3d1e6", -- Darker fg (status line)
-  fg3     = "#555169", -- Darker fg (line numbers, fold colums)
+  fg2     = "#cdcbe0", -- Darker fg (status line)
+  fg3     = "#6e6a86", -- Darker fg (line numbers, fold colums)
 
   sel0    = "#433c59", -- Popup bg, visual selection bg
   sel1    = "#63577d", -- Popup sel bg, search bg

--- a/lua/nightfox/precompiled/dawnfox_compiled.lua
+++ b/lua/nightfox/precompiled/dawnfox_compiled.lua
@@ -85,8 +85,8 @@ highlight Error guifg=#b4637a guibg=NONE gui=NONE guisp=NONE |
 highlight ErrorMsg guifg=#b4637a guibg=NONE gui=NONE guisp=NONE |
 highlight FernBranchText guifg=#286983 guibg=NONE gui=NONE guisp=NONE |
 highlight FloatBorder guifg=#a8a3b3 guibg=NONE gui=NONE guisp=NONE |
-highlight FoldColumn guifg=#ebdfe4 guibg=NONE gui=NONE guisp=NONE |
-highlight Folded guifg=#a8a3b3 guibg=#ebdfe4 gui=NONE guisp=NONE |
+highlight FoldColumn guifg=#a8a3b3 guibg=NONE gui=NONE guisp=NONE |
+highlight Folded guifg=#a8a3b3 guibg=#ebe0df gui=NONE guisp=NONE |
 highlight Function guifg=#295e73 guibg=NONE gui=NONE guisp=NONE |
 highlight GitGutterAdd guifg=#618774 guibg=NONE gui=NONE guisp=NONE |
 highlight GitGutterChange guifg=#ea9d34 guibg=NONE gui=NONE guisp=NONE |

--- a/lua/nightfox/precompiled/dayfox_compiled.lua
+++ b/lua/nightfox/precompiled/dayfox_compiled.lua
@@ -85,8 +85,8 @@ highlight Error guifg=#b95d76 guibg=NONE gui=NONE guisp=NONE |
 highlight ErrorMsg guifg=#b95d76 guibg=NONE gui=NONE guisp=NONE |
 highlight FernBranchText guifg=#4d688e guibg=NONE gui=NONE guisp=NONE |
 highlight FloatBorder guifg=#2e537d guibg=NONE gui=NONE guisp=NONE |
-highlight FoldColumn guifg=#ced6db guibg=NONE gui=NONE guisp=NONE |
-highlight Folded guifg=#2e537d guibg=#ced6db gui=NONE guisp=NONE |
+highlight FoldColumn guifg=#2e537d guibg=NONE gui=NONE guisp=NONE |
+highlight Folded guifg=#2e537d guibg=#dbcece gui=NONE guisp=NONE |
 highlight Function guifg=#485e7d guibg=NONE gui=NONE guisp=NONE |
 highlight GitGutterAdd guifg=#618774 guibg=NONE gui=NONE guisp=NONE |
 highlight GitGutterChange guifg=#ba793e guibg=NONE gui=NONE guisp=NONE |

--- a/lua/nightfox/precompiled/duskfox_compiled.lua
+++ b/lua/nightfox/precompiled/duskfox_compiled.lua
@@ -10,11 +10,11 @@ end
 -- Highlight group definitions
 cmd([[
 highlight Bold guifg=NONE guibg=NONE gui=bold guisp=NONE |
-highlight BufferCurrent guifg=#e0def4 guibg=#555169 gui=NONE guisp=NONE |
-highlight BufferCurrentIndex guifg=#569fba guibg=#555169 gui=NONE guisp=NONE |
-highlight BufferCurrentMod guifg=#f6c177 guibg=#555169 gui=NONE guisp=NONE |
-highlight BufferCurrentSign guifg=#569fba guibg=#555169 gui=NONE guisp=NONE |
-highlight BufferCurrentTarget guifg=#eb6f92 guibg=#555169 gui=NONE guisp=NONE |
+highlight BufferCurrent guifg=#e0def4 guibg=#6e6a86 gui=NONE guisp=NONE |
+highlight BufferCurrentIndex guifg=#569fba guibg=#6e6a86 gui=NONE guisp=NONE |
+highlight BufferCurrentMod guifg=#f6c177 guibg=#6e6a86 gui=NONE guisp=NONE |
+highlight BufferCurrentSign guifg=#569fba guibg=#6e6a86 gui=NONE guisp=NONE |
+highlight BufferCurrentTarget guifg=#eb6f92 guibg=#6e6a86 gui=NONE guisp=NONE |
 highlight BufferInactive guifg=#817c9c guibg=#191726 gui=NONE guisp=NONE |
 highlight BufferInactiveIndex guifg=#817c9c guibg=#191726 gui=NONE guisp=NONE |
 highlight BufferInactiveMod guifg=#433940 guibg=#191726 gui=NONE guisp=NONE |
@@ -49,11 +49,11 @@ highlight BufferVisibleTarget guifg=#eb6f92 guibg=#191726 gui=NONE guisp=NONE |
 highlight CmpDocumentation guifg=#e0def4 guibg=#191726 gui=NONE guisp=NONE |
 highlight CmpDocumentationBorder guifg=#433c59 guibg=#191726 gui=NONE guisp=NONE |
 highlight CmpItemAbbr guifg=#e0def4 guibg=NONE gui=NONE guisp=NONE |
-highlight CmpItemAbbrDeprecated guifg=#555169 guibg=NONE gui=strikethrough guisp=NONE |
+highlight CmpItemAbbrDeprecated guifg=#6e6a86 guibg=NONE gui=strikethrough guisp=NONE |
 highlight CmpItemAbbrMatch guifg=#65b1cd guibg=NONE gui=NONE guisp=NONE |
 highlight CmpItemAbbrMatchFuzzy guifg=#65b1cd guibg=NONE gui=NONE guisp=NONE |
-highlight CmpItemKindDefault guifg=#d3d1e6 guibg=NONE gui=NONE guisp=NONE |
-highlight CmpItemKindSnippet guifg=#d3d1e6 guibg=NONE gui=NONE guisp=NONE |
+highlight CmpItemKindDefault guifg=#cdcbe0 guibg=NONE gui=NONE guisp=NONE |
+highlight CmpItemKindSnippet guifg=#cdcbe0 guibg=NONE gui=NONE guisp=NONE |
 highlight ColorColumn guifg=NONE guibg=#2d2a45 gui=NONE guisp=NONE |
 highlight Comment guifg=#817c9c guibg=NONE gui=NONE guisp=NONE |
 highlight Conceal guifg=#4b4673 guibg=NONE gui=NONE guisp=NONE |
@@ -84,9 +84,9 @@ highlight EndOfBuffer guifg=#232136 guibg=NONE gui=NONE guisp=NONE |
 highlight Error guifg=#eb6f92 guibg=NONE gui=NONE guisp=NONE |
 highlight ErrorMsg guifg=#eb6f92 guibg=NONE gui=NONE guisp=NONE |
 highlight FernBranchText guifg=#569fba guibg=NONE gui=NONE guisp=NONE |
-highlight FloatBorder guifg=#555169 guibg=NONE gui=NONE guisp=NONE |
-highlight FoldColumn guifg=#373354 guibg=NONE gui=NONE guisp=NONE |
-highlight Folded guifg=#555169 guibg=#373354 gui=NONE guisp=NONE |
+highlight FloatBorder guifg=#6e6a86 guibg=NONE gui=NONE guisp=NONE |
+highlight FoldColumn guifg=#6e6a86 guibg=NONE gui=NONE guisp=NONE |
+highlight Folded guifg=#6e6a86 guibg=#2d2a45 gui=NONE guisp=NONE |
 highlight Function guifg=#65b1cd guibg=NONE gui=NONE guisp=NONE |
 highlight GitGutterAdd guifg=#a3be8c guibg=NONE gui=NONE guisp=NONE |
 highlight GitGutterChange guifg=#f6c177 guibg=NONE gui=NONE guisp=NONE |
@@ -119,24 +119,24 @@ highlight IncSearch guifg=#433c59 guibg=#a3be8c gui=NONE guisp=NONE |
 highlight Italic guifg=NONE guibg=NONE gui=italic guisp=NONE |
 highlight Keyword guifg=#c4a7e7 guibg=NONE gui=NONE guisp=NONE |
 highlight LightspeedGreyWash guifg=#817c9c guibg=NONE gui=NONE guisp=NONE |
-highlight LineNr guifg=#555169 guibg=NONE gui=NONE guisp=NONE |
+highlight LineNr guifg=#6e6a86 guibg=NONE gui=NONE guisp=NONE |
 highlight LspCodeLens guifg=#817c9c guibg=NONE gui=NONE guisp=NONE |
-highlight LspCodeLensSeparator guifg=#555169 guibg=NONE gui=NONE guisp=NONE |
-highlight LspFloatWinBorder guifg=#555169 guibg=NONE gui=NONE guisp=NONE |
+highlight LspCodeLensSeparator guifg=#6e6a86 guibg=NONE gui=NONE guisp=NONE |
+highlight LspFloatWinBorder guifg=#6e6a86 guibg=NONE gui=NONE guisp=NONE |
 highlight LspFloatWinNormal guifg=NONE guibg=#191726 gui=NONE guisp=NONE |
 highlight LspReferenceRead guifg=NONE guibg=#433c59 gui=NONE guisp=NONE |
 highlight LspReferenceText guifg=NONE guibg=#433c59 gui=NONE guisp=NONE |
 highlight LspReferenceWrite guifg=NONE guibg=#433c59 gui=NONE guisp=NONE |
-highlight LspSagaCodeActionBorder guifg=#555169 guibg=NONE gui=NONE guisp=NONE |
-highlight LspSagaDefPreviewBorder guifg=#555169 guibg=NONE gui=NONE guisp=NONE |
+highlight LspSagaCodeActionBorder guifg=#6e6a86 guibg=NONE gui=NONE guisp=NONE |
+highlight LspSagaDefPreviewBorder guifg=#6e6a86 guibg=NONE gui=NONE guisp=NONE |
 highlight LspSagaFinderSelection guifg=#433c59 guibg=NONE gui=NONE guisp=NONE |
-highlight LspSagaHoverBorder guifg=#555169 guibg=NONE gui=NONE guisp=NONE |
-highlight LspSagaRenameBorder guifg=#555169 guibg=NONE gui=NONE guisp=NONE |
+highlight LspSagaHoverBorder guifg=#6e6a86 guibg=NONE gui=NONE guisp=NONE |
+highlight LspSagaRenameBorder guifg=#6e6a86 guibg=NONE gui=NONE guisp=NONE |
 highlight LspSagaSignatureHelpBorder guifg=#eb6f92 guibg=NONE gui=NONE guisp=NONE |
 highlight LspSignatureActiveParameter guifg=#63577d guibg=NONE gui=NONE guisp=NONE |
-highlight LspTroubleCount guifg=#c4a7e7 guibg=#555169 gui=NONE guisp=NONE |
-highlight LspTroubleNormal guifg=#555169 guibg=#191726 gui=NONE guisp=NONE |
-highlight LspTroubleText guifg=#d3d1e6 guibg=NONE gui=NONE guisp=NONE |
+highlight LspTroubleCount guifg=#c4a7e7 guibg=#6e6a86 gui=NONE guisp=NONE |
+highlight LspTroubleNormal guifg=#6e6a86 guibg=#191726 gui=NONE guisp=NONE |
+highlight LspTroubleText guifg=#cdcbe0 guibg=NONE gui=NONE guisp=NONE |
 highlight MatchParen guifg=#f6c177 guibg=NONE gui=bold guisp=NONE |
 highlight ModeMsg guifg=#f6c177 guibg=NONE gui=bold guisp=NONE |
 highlight ModesCopy guifg=NONE guibg=#f6c177 gui=NONE guisp=NONE |
@@ -147,7 +147,7 @@ highlight MoreMsg guifg=#569fba guibg=NONE gui=bold guisp=NONE |
 highlight NeoTreeDirectoryIcon guifg=#569fba guibg=NONE gui=NONE guisp=NONE |
 highlight NeoTreeDirectoryName guifg=#569fba guibg=NONE gui=NONE guisp=NONE |
 highlight NeoTreeDotfile guifg=#4a869c guibg=NONE gui=NONE guisp=NONE |
-highlight NeoTreeFileName guifg=#d3d1e6 guibg=NONE gui=NONE guisp=NONE |
+highlight NeoTreeFileName guifg=#cdcbe0 guibg=NONE gui=NONE guisp=NONE |
 highlight NeoTreeFileNameOpened guifg=#e0def4 guibg=NONE gui=NONE guisp=NONE |
 highlight NeoTreeGitAdded guifg=#a3be8c guibg=NONE gui=NONE guisp=NONE |
 highlight NeoTreeGitConflict guifg=#ea9a97 guibg=NONE gui=italic guisp=NONE |
@@ -176,7 +176,7 @@ highlight Normal guifg=#e0def4 guibg=#232136 gui=NONE guisp=NONE |
 highlight NormalFloat guifg=#e0def4 guibg=#191726 gui=NONE guisp=NONE |
 highlight NormalNC guifg=#e0def4 guibg=#232136 gui=NONE guisp=NONE |
 highlight Number guifg=#ea9a97 guibg=NONE gui=NONE guisp=NONE |
-highlight NvimTreeEmptyFolderName guifg=#555169 guibg=NONE gui=NONE guisp=NONE |
+highlight NvimTreeEmptyFolderName guifg=#6e6a86 guibg=NONE gui=NONE guisp=NONE |
 highlight NvimTreeFolderIcon guifg=#569fba guibg=NONE gui=NONE guisp=NONE |
 highlight NvimTreeFolderName guifg=#569fba guibg=NONE gui=NONE guisp=NONE |
 highlight NvimTreeGitDeleted guifg=#eb6f92 guibg=NONE gui=NONE guisp=NONE |
@@ -191,7 +191,7 @@ highlight NvimTreeOpenedFolderName guifg=#65b1cd guibg=NONE gui=NONE guisp=NONE 
 highlight NvimTreeRootFolder guifg=#ea9a97 guibg=NONE gui=bold guisp=NONE |
 highlight NvimTreeSpecialFile guifg=#9ccfd8 guibg=NONE gui=NONE guisp=NONE |
 highlight NvimTreeSymlink guifg=#d871a6 guibg=NONE gui=NONE guisp=NONE |
-highlight Operator guifg=#d3d1e6 guibg=NONE gui=NONE guisp=NONE |
+highlight Operator guifg=#cdcbe0 guibg=NONE gui=NONE guisp=NONE |
 highlight Pmenu guifg=#e0def4 guibg=#433c59 gui=NONE guisp=NONE |
 highlight PmenuSel guifg=NONE guibg=#63577d gui=NONE guisp=NONE |
 highlight PmenuThumb guifg=NONE guibg=#63577d gui=NONE guisp=NONE |
@@ -201,7 +201,7 @@ highlight PounceGap guifg=#e0def4 guibg=#433c59 gui=NONE guisp=NONE |
 highlight PounceMatch guifg=#e0def4 guibg=#63577d gui=NONE guisp=NONE |
 highlight PreProc guifg=#f0a6cc guibg=NONE gui=NONE guisp=NONE |
 highlight Search guifg=#e0def4 guibg=#63577d gui=NONE guisp=NONE |
-highlight SignColumn guifg=#555169 guibg=NONE gui=NONE guisp=NONE |
+highlight SignColumn guifg=#6e6a86 guibg=NONE gui=NONE guisp=NONE |
 highlight Sneak guifg=#191726 guibg=#c4a7e7 gui=NONE guisp=NONE |
 highlight SneakScope guifg=NONE guibg=#433c59 gui=NONE guisp=NONE |
 highlight Special guifg=#65b1cd guibg=NONE gui=NONE guisp=NONE |
@@ -210,8 +210,8 @@ highlight SpellCap guifg=NONE guibg=NONE gui=undercurl guisp=#f6c177 |
 highlight SpellLocal guifg=NONE guibg=NONE gui=undercurl guisp=#569fba |
 highlight SpellRare guifg=NONE guibg=NONE gui=undercurl guisp=#569fba |
 highlight Statement guifg=#c4a7e7 guibg=NONE gui=NONE guisp=NONE |
-highlight StatusLine guifg=#d3d1e6 guibg=#191726 gui=NONE guisp=NONE |
-highlight StatusLineNC guifg=#555169 guibg=#191726 gui=NONE guisp=NONE |
+highlight StatusLine guifg=#cdcbe0 guibg=#191726 gui=NONE guisp=NONE |
+highlight StatusLineNC guifg=#6e6a86 guibg=#191726 gui=NONE guisp=NONE |
 highlight String guifg=#a3be8c guibg=NONE gui=NONE guisp=NONE |
 highlight Substitute guifg=#232136 guibg=#eb6f92 gui=NONE guisp=NONE |
 highlight TSConstBuiltin guifg=#f0a4a2 guibg=NONE gui=NONE guisp=NONE |
@@ -222,13 +222,13 @@ highlight TSField guifg=#569fba guibg=NONE gui=NONE guisp=NONE |
 highlight TSFuncBuiltin guifg=#eb6f92 guibg=NONE gui=NONE guisp=NONE |
 highlight TSFuncMacro guifg=#eb6f92 guibg=NONE gui=NONE guisp=NONE |
 highlight TSKeywordFunction guifg=#eb6f92 guibg=NONE gui=NONE guisp=NONE |
-highlight TSKeywordOperator guifg=#d3d1e6 guibg=NONE gui=bold guisp=NONE |
+highlight TSKeywordOperator guifg=#cdcbe0 guibg=NONE gui=bold guisp=NONE |
 highlight TSNamespace guifg=#a6dae3 guibg=NONE gui=NONE guisp=NONE |
 highlight TSNote guifg=#569fba guibg=NONE gui=NONE guisp=NONE |
-highlight TSOperator guifg=#d3d1e6 guibg=NONE gui=NONE guisp=NONE |
-highlight TSPunctBracket guifg=#d3d1e6 guibg=NONE gui=NONE guisp=NONE |
-highlight TSPunctDelimiter guifg=#d3d1e6 guibg=NONE gui=NONE guisp=NONE |
-highlight TSPunctSpecial guifg=#d3d1e6 guibg=NONE gui=NONE guisp=NONE |
+highlight TSOperator guifg=#cdcbe0 guibg=NONE gui=NONE guisp=NONE |
+highlight TSPunctBracket guifg=#cdcbe0 guibg=NONE gui=NONE guisp=NONE |
+highlight TSPunctDelimiter guifg=#cdcbe0 guibg=NONE gui=NONE guisp=NONE |
+highlight TSPunctSpecial guifg=#cdcbe0 guibg=NONE gui=NONE guisp=NONE |
 highlight TSStringEscape guifg=#f9cb8c guibg=NONE gui=bold guisp=NONE |
 highlight TSStringRegex guifg=#f9cb8c guibg=NONE gui=NONE guisp=NONE |
 highlight TSTextReference guifg=#c4a7e7 guibg=NONE gui=NONE guisp=NONE |
@@ -237,9 +237,9 @@ highlight TSURI guifg=#9ccfd8 guibg=NONE gui=bold guisp=NONE |
 highlight TSVariable guifg=#e0def4 guibg=NONE gui=NONE guisp=NONE |
 highlight TSVariableBuiltin guifg=#eb6f92 guibg=NONE gui=NONE guisp=NONE |
 highlight TSWarning guifg=#f6c177 guibg=NONE gui=NONE guisp=NONE |
-highlight TabLine guifg=#555169 guibg=#2d2a45 gui=NONE guisp=NONE |
+highlight TabLine guifg=#6e6a86 guibg=#2d2a45 gui=NONE guisp=NONE |
 highlight TabLineFill guifg=NONE guibg=#191726 gui=NONE guisp=NONE |
-highlight TabLineSel guifg=#d3d1e6 guibg=#4b4673 gui=NONE guisp=NONE |
+highlight TabLineSel guifg=#cdcbe0 guibg=#4b4673 gui=NONE guisp=NONE |
 highlight TelescopeBorder guifg=#4b4673 guibg=NONE gui=NONE guisp=NONE |
 highlight TelescopeSelectionCaret guifg=#a3be8c guibg=NONE gui=NONE guisp=NONE |
 highlight Title guifg=#65b1cd guibg=NONE gui=NONE guisp=NONE |
@@ -266,7 +266,7 @@ highlight rainbowcol4 guifg=#569fba guibg=NONE gui=NONE guisp=NONE |
 highlight rainbowcol5 guifg=#9ccfd8 guibg=NONE gui=NONE guisp=NONE |
 highlight rainbowcol6 guifg=#c4a7e7 guibg=NONE gui=NONE guisp=NONE |
 highlight rainbowcol7 guifg=#eb98c3 guibg=NONE gui=NONE guisp=NONE |
-highlight rustTSField guifg=#d3d1e6 guibg=NONE gui=NONE guisp=NONE
+highlight rustTSField guifg=#cdcbe0 guibg=NONE gui=NONE guisp=NONE
 ]])
 
 -- Highlight link definitions

--- a/lua/nightfox/precompiled/nightfox_compiled.lua
+++ b/lua/nightfox/precompiled/nightfox_compiled.lua
@@ -85,8 +85,8 @@ highlight Error guifg=#c94f6d guibg=NONE gui=NONE guisp=NONE |
 highlight ErrorMsg guifg=#c94f6d guibg=NONE gui=NONE guisp=NONE |
 highlight FernBranchText guifg=#719cd6 guibg=NONE gui=NONE guisp=NONE |
 highlight FloatBorder guifg=#71839b guibg=NONE gui=NONE guisp=NONE |
-highlight FoldColumn guifg=#29394e guibg=NONE gui=NONE guisp=NONE |
-highlight Folded guifg=#71839b guibg=#29394e gui=NONE guisp=NONE |
+highlight FoldColumn guifg=#71839b guibg=NONE gui=NONE guisp=NONE |
+highlight Folded guifg=#71839b guibg=#212e3f gui=NONE guisp=NONE |
 highlight Function guifg=#86abdc guibg=NONE gui=NONE guisp=NONE |
 highlight GitGutterAdd guifg=#81b29a guibg=NONE gui=NONE guisp=NONE |
 highlight GitGutterChange guifg=#dbc074 guibg=NONE gui=NONE guisp=NONE |

--- a/lua/nightfox/precompiled/nordfox_compiled.lua
+++ b/lua/nightfox/precompiled/nordfox_compiled.lua
@@ -85,8 +85,8 @@ highlight Error guifg=#bf616a guibg=NONE gui=NONE guisp=NONE |
 highlight ErrorMsg guifg=#bf616a guibg=NONE gui=NONE guisp=NONE |
 highlight FernBranchText guifg=#81a1c1 guibg=NONE gui=NONE guisp=NONE |
 highlight FloatBorder guifg=#7e8188 guibg=NONE gui=NONE guisp=NONE |
-highlight FoldColumn guifg=#444c5e guibg=NONE gui=NONE guisp=NONE |
-highlight Folded guifg=#7e8188 guibg=#444c5e gui=NONE guisp=NONE |
+highlight FoldColumn guifg=#7e8188 guibg=NONE gui=NONE guisp=NONE |
+highlight Folded guifg=#7e8188 guibg=#39404f gui=NONE guisp=NONE |
 highlight Function guifg=#8cafd2 guibg=NONE gui=NONE guisp=NONE |
 highlight GitGutterAdd guifg=#a3be8c guibg=NONE gui=NONE guisp=NONE |
 highlight GitGutterChange guifg=#ebcb8b guibg=NONE gui=NONE guisp=NONE |

--- a/lua/nightfox/precompiled/terafox_compiled.lua
+++ b/lua/nightfox/precompiled/terafox_compiled.lua
@@ -85,8 +85,8 @@ highlight Error guifg=#e85c51 guibg=NONE gui=NONE guisp=NONE |
 highlight ErrorMsg guifg=#e85c51 guibg=NONE gui=NONE guisp=NONE |
 highlight FernBranchText guifg=#5a93aa guibg=NONE gui=NONE guisp=NONE |
 highlight FloatBorder guifg=#587b7b guibg=NONE gui=NONE guisp=NONE |
-highlight FoldColumn guifg=#254147 guibg=NONE gui=NONE guisp=NONE |
-highlight Folded guifg=#587b7b guibg=#254147 gui=NONE guisp=NONE |
+highlight FoldColumn guifg=#587b7b guibg=NONE gui=NONE guisp=NONE |
+highlight Folded guifg=#587b7b guibg=#1d3337 gui=NONE guisp=NONE |
 highlight Function guifg=#73a3b7 guibg=NONE gui=NONE guisp=NONE |
 highlight GitGutterAdd guifg=#7aa4a1 guibg=NONE gui=NONE guisp=NONE |
 highlight GitGutterChange guifg=#fda47f guibg=NONE gui=NONE guisp=NONE |


### PR DESCRIPTION
This change increases the contrast between folds fg and bg by moving the bg from `bg3` to `bg2`. This is what folds were supposed to be.

Duskfox also has increased the brightness of fg3 (line numbers and and fold fg). As well it also added slightly more contrast between `fg1` (default) and `fg2` (alt).

### Old
![old-folds](https://user-images.githubusercontent.com/2746374/162004840-67b8cc3b-47e1-4dd8-9828-983049037f30.png)

### New
![new-folds](https://user-images.githubusercontent.com/2746374/162004885-dcd4040a-36b6-4f4a-86ea-a4e0be332044.png)

Resolves: #120 
