### PR TITLE
docs(readme): Fix default option example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -163,8 +163,8 @@ certain syntax is the only desired change then your options table would look lik
 require('nightfox').setup({
   options = {
     styles = {
-      commnets = "italic",
-      keywords = "bold"
+      comments = "italic",
+      keywords = "bold",
       types = "italic,bold",
     }
   }


### PR DESCRIPTION
I realized there were some issues with the example. Namely "commnets" typo and a missing comma.

Tested with my config and it worked after changes.