### PR TITLE
`all` override for `palette` and `spec`

### DIFF
--- a/lua/nightfox/palette.lua
+++ b/lua/nightfox/palette.lua
@@ -44,37 +44,19 @@ M.foxes = {
   "terafox",
 }
 
-local function override(color, ovr)
-  local color_list = { "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white", "orange", "pink" }
-  local single_list = { "comment", "bg0", "bg1", "bg2", "bg3", "bg4", "fg0", "fg1", "fg2", "fg3", "sel0", "sel1" }
-
-  for _, name in ipairs(color_list) do
-    if ovr[name] then
-      if type(ovr[name]) == "string" then
-        color[name].base = ovr[name]
-      else
-        for k, v in pairs(ovr[name]) do
-          color[name][k] = type(v) == "table" and v:to_css() or v
-        end
-      end
-    end
-  end
-
-  for _, name in ipairs(single_list) do
-    if ovr[name] then
-      local v = ovr[name]
-      color[name] = type(v) == "table" and v:to_css() or v
-    end
-  end
-end
-
 function M.load(name)
   local ovr = require("nightfox.override").palettes
+
+  local function apply_ovr(key, palette)
+    return ovr[key] and collect.deep_extend(palette, ovr[key]) or palette
+  end
 
   if name then
     local valid = collect.contains(M.foxes, name)
     local raw = valid and require("nightfox.palette." .. name) or require("nightfox.palette.nightfox")
-    local palette = ovr[name] and override(raw.palette, ovr[name]) or raw.palette
+    local palette = raw.palette
+    palette = apply_ovr("all", palette)
+    palette = apply_ovr(name, palette)
     palette.meta = raw.meta
     palette.generate_spec = raw.generate_spec
     return palette
@@ -82,7 +64,9 @@ function M.load(name)
     local result = {}
     for _, mod in ipairs(M.foxes) do
       local raw = require("nightfox.palette." .. mod)
-      local palette = ovr[mod] and override(raw.palette, ovr[mod]) or raw.palette
+      local palette = raw.palette
+      palette = apply_ovr("all", palette)
+      palette = apply_ovr(mod, palette)
       palette.meta = raw.meta
       palette.generate_spec = raw.generate_spec
       result[mod] = palette

--- a/lua/nightfox/palette.lua
+++ b/lua/nightfox/palette.lua
@@ -44,11 +44,25 @@ M.foxes = {
   "terafox",
 }
 
+local function override(color, ovr)
+  for key, value in pairs(ovr) do
+    if type(value) == "string" then
+      color[key].base = value
+    else
+      for k, v in pairs(value) do
+        color[key][k] = v
+      end
+    end
+  end
+
+  return color
+end
+
 function M.load(name)
   local ovr = require("nightfox.override").palettes
 
   local function apply_ovr(key, palette)
-    return ovr[key] and collect.deep_extend(palette, ovr[key]) or palette
+    return ovr[key] and override(palette, ovr[key]) or palette
   end
 
   if name then

--- a/lua/nightfox/util/template.lua
+++ b/lua/nightfox/util/template.lua
@@ -41,12 +41,15 @@ function M.parse(template, spec)
   local result = {}
 
   for group, opts in pairs(template) do
-    local new = {}
-    for key, value in pairs(opts) do
-      new[key] = type(value) == "table" and to_value(value) or parse_string(value, spec)
+    if type(opts) == "table" then
+      local new = {}
+      for key, value in pairs(opts) do
+        new[key] = type(value) == "table" and to_value(value) or parse_string(value, spec)
+      end
+      result[group] = new
+    else
+      result[group] = parse_string(opts, spec)
     end
-
-    result[group] = new
   end
 
   return result

--- a/readme.md
+++ b/readme.md
@@ -191,20 +191,25 @@ You can change the color `palette` and the highlight `group` of nightfox. Here i
 
 ```lua
 -- Palettes are the base color defines of a colorscheme.
--- You can override these palettes for each colorscheme defined by nightfox
+-- You can override these palettes for each colorscheme defined by nightfox.
 local palettes = {
-  nightfox = {
+  -- Everything defined under `all` will be applied to each style.
+  all = {
     -- Each palette defines these colors:
     --   black, red, green, yellow, blue, magenta, cyan, white, orange, pink
     --
     -- These colors have 3 shades: base, bright, and dim
     --
     -- Defining just a color defines it's base color
+    red = "#ff0000",
+  },
+  nightfox = {
+    -- A specific style's value will be used over the `all`'s value
     red = "#c94f6d",
   },
   dayfox = {
     -- Defining multiple shades is done by passing a table
-    blue = { base = "#4d688e", bright = "#4e75aa", dim = "#485e7d", }
+    blue = { base = "#4d688e", bright = "#4e75aa", dim = "#485e7d" },
   },
   nordfox = {
     -- A palette also defines the following:
@@ -221,7 +226,7 @@ local palettes = {
 
     -- comment is the definition of the comment color.
     comment = "#60728a",
-  }
+  },
 }
 
 -- Spec's (specifications) are a mapping of palettes to logical groups that will be
@@ -232,7 +237,8 @@ local palettes = {
 --
 -- You can override these just like palettes
 local specs = {
-  nightfox = {
+  -- As with palettes, the values defined under `all` will be applied to every style.
+  all = {
     syntax = {
       -- Specs allow you to define a value using either a color or template. If the string does
       -- start with `#` the string will be used as the path of the palette table. Defining just
@@ -246,8 +252,14 @@ local specs = {
     git = {
       -- A color define can also be used
       changed = "#f4a261",
-    }
-  }
+    },
+  },
+  nightfox = {
+    syntax = {
+      -- As with palettes, a specific style's value will be used over the `all`'s value.
+      operator = "orange",
+    },
+  },
 }
 
 -- Groups are the highlight group definitions. The keys of this table are the name of the highlight
@@ -270,11 +282,12 @@ require("nightfox").setup({ palettes = palettes, specs = specs, groups = groups 
 vim.cmd("colorscheme nightfox")
 ```
 
-To find the list of syntax highlight groups defined for vim use the help `:help group-name` and `:help nvim-treesitter-highlights` for treesitter. If you would also like to see how nightfox defines these highlight groups
+To find the list of syntax highlight groups defined for vim use the help `:help group-name` and `:help
+nvim-treesitter-highlights` for treesitter. If you would also like to see how nightfox defines these highlight groups
 you can see [syntax.lua] for vim's syntax and [treesitter.lua] for treesitter. These files list out all all highlight
 groups and have a comment describing them. Another file to note is [editor.lua] which is the highlight groups respncible
-for how vim looks (background, cursorline, tabline, etc...). To get the highlight group under your cursor see [here](#syntax-highlight-groups) for
-more information
+for how vim looks (background, cursorline, tabline, etc...). To get the highlight group under your cursor see
+[here](#syntax-highlight-groups) for more information
 
 To get more information check out [Usage](./usage.md#configuration) or the help file `:help nightfox` for more detailed information.
 


### PR DESCRIPTION
This pr updates overrides for `palettes` and `specs` to take an `all` table. Values defined in this table will apply to **all** styles. This makes something like overriding a spec for example a lot easier.

From:

```lua
require("nightfox").setup({
  specs = {
    nightfox = { syntax = { operator = "orange", }, },
    dayfox = { syntax = { operator = "orange", }, },
    duskfox = { syntax = { operator = "orange", }, },
    dawnfox = { syntax = { operator = "orange", }, },
    nordfox = { syntax = { operator = "orange", }, },
    terafox = { syntax = { operator = "orange", }, },
  },
})
```

To

```lua
require("nightfox").setup({
  specs = {
    all = {
      syntax = {
        operator = "orange",
      },
    },
  },
})
```