### PR TITLE
fix(lib): Hackly workaround for neovim core bug

### DIFF
--- a/lua/nightfox/lib/highlight.lua
+++ b/lua/nightfox/lib/highlight.lua
@@ -84,6 +84,7 @@ local function nvim_hl(highlights)
 end
 
 if util.use_nvim_api then
+  M.alt_highlight = viml_hl
   M.highlight = nvim_hl
 else
   M.highlight = viml_hl

--- a/lua/nightfox/main.lua
+++ b/lua/nightfox/main.lua
@@ -73,6 +73,13 @@ function M.load(opts)
     set_info(spec)
     hl.highlight(groups)
 
+    -- HACK: There is an issue with `nvim_set_hl` currently where calling `vim.api.nvim_get_hl_by_name("Normal", true)` will
+    -- return `{ [true] = 6 }` if we are using this api_call then we have to set Normal with `:highlight` command to get
+    -- around this for now
+    if util.use_nvim_api then
+      hl.alt_highlight({ Normal = groups.Normal })
+    end
+
     if config.options.terminal_colors then
       set_terminal_colors(spec)
     end

--- a/lua/nightfox/precompiled/nvim/dawnfox_compiled.lua
+++ b/lua/nightfox/precompiled/nvim/dawnfox_compiled.lua
@@ -348,6 +348,10 @@ vim.api.nvim_set_hl(0, "rainbowcol6", { fg = "#907aa9" })
 vim.api.nvim_set_hl(0, "rainbowcol7", { fg = "#d685af" })
 vim.api.nvim_set_hl(0, "rustTSField", { fg = "#625c87" })
 
+-- This is a hack as currently `nvim_set_hl` returns `{ [true] = 6 }`
+-- if `Normal` is requested from `nvim_get_hl_by_name("Normal", true)`
+vim.cmd("highlight Normal guifg=#575279 guibg=#faf4ed gui=NONE guisp=NONE")
+
 local function set_terminal()
    -- stylua: ignore
   local colors = {

--- a/lua/nightfox/precompiled/nvim/dayfox_compiled.lua
+++ b/lua/nightfox/precompiled/nvim/dayfox_compiled.lua
@@ -348,6 +348,10 @@ vim.api.nvim_set_hl(0, "rainbowcol6", { fg = "#8e6f98" })
 vim.api.nvim_set_hl(0, "rainbowcol7", { fg = "#d685af" })
 vim.api.nvim_set_hl(0, "rustTSField", { fg = "#233f5e" })
 
+-- This is a hack as currently `nvim_set_hl` returns `{ [true] = 6 }`
+-- if `Normal` is requested from `nvim_get_hl_by_name("Normal", true)`
+vim.cmd("highlight Normal guifg=#1d344f guibg=#eaeaea gui=NONE guisp=NONE")
+
 local function set_terminal()
    -- stylua: ignore
   local colors = {

--- a/lua/nightfox/precompiled/nvim/duskfox_compiled.lua
+++ b/lua/nightfox/precompiled/nvim/duskfox_compiled.lua
@@ -348,6 +348,10 @@ vim.api.nvim_set_hl(0, "rainbowcol6", { fg = "#c4a7e7" })
 vim.api.nvim_set_hl(0, "rainbowcol7", { fg = "#eb98c3" })
 vim.api.nvim_set_hl(0, "rustTSField", { fg = "#cdcbe0" })
 
+-- This is a hack as currently `nvim_set_hl` returns `{ [true] = 6 }`
+-- if `Normal` is requested from `nvim_get_hl_by_name("Normal", true)`
+vim.cmd("highlight Normal guifg=#e0def4 guibg=#232136 gui=NONE guisp=NONE")
+
 local function set_terminal()
    -- stylua: ignore
   local colors = {

--- a/lua/nightfox/precompiled/nvim/nightfox_compiled.lua
+++ b/lua/nightfox/precompiled/nvim/nightfox_compiled.lua
@@ -348,6 +348,10 @@ vim.api.nvim_set_hl(0, "rainbowcol6", { fg = "#9d79d6" })
 vim.api.nvim_set_hl(0, "rainbowcol7", { fg = "#d67ad2" })
 vim.api.nvim_set_hl(0, "rustTSField", { fg = "#aeafb0" })
 
+-- This is a hack as currently `nvim_set_hl` returns `{ [true] = 6 }`
+-- if `Normal` is requested from `nvim_get_hl_by_name("Normal", true)`
+vim.cmd("highlight Normal guifg=#cdcecf guibg=#192330 gui=NONE guisp=NONE")
+
 local function set_terminal()
    -- stylua: ignore
   local colors = {

--- a/lua/nightfox/precompiled/nvim/nordfox_compiled.lua
+++ b/lua/nightfox/precompiled/nvim/nordfox_compiled.lua
@@ -348,6 +348,10 @@ vim.api.nvim_set_hl(0, "rainbowcol6", { fg = "#b48ead" })
 vim.api.nvim_set_hl(0, "rainbowcol7", { fg = "#bf88bc" })
 vim.api.nvim_set_hl(0, "rustTSField", { fg = "#abb1bb" })
 
+-- This is a hack as currently `nvim_set_hl` returns `{ [true] = 6 }`
+-- if `Normal` is requested from `nvim_get_hl_by_name("Normal", true)`
+vim.cmd("highlight Normal guifg=#cdcecf guibg=#2e3440 gui=NONE guisp=NONE")
+
 local function set_terminal()
    -- stylua: ignore
   local colors = {

--- a/lua/nightfox/precompiled/nvim/terafox_compiled.lua
+++ b/lua/nightfox/precompiled/nvim/terafox_compiled.lua
@@ -348,6 +348,10 @@ vim.api.nvim_set_hl(0, "rainbowcol6", { fg = "#ad5c7c" })
 vim.api.nvim_set_hl(0, "rainbowcol7", { fg = "#cb7985" })
 vim.api.nvim_set_hl(0, "rustTSField", { fg = "#cbd9d8" })
 
+-- This is a hack as currently `nvim_set_hl` returns `{ [true] = 6 }`
+-- if `Normal` is requested from `nvim_get_hl_by_name("Normal", true)`
+vim.cmd("highlight Normal guifg=#e6eaea guibg=#152528 gui=NONE guisp=NONE")
+
 local function set_terminal()
    -- stylua: ignore
   local colors = {


### PR DESCRIPTION
There is an issue with setting `Normal` highlight using `nvim_set_hl`.
When getting the results with `nvim_get_hl_by_name("Normal", true)` this
returns:

```
{
  [true] = 6
}
```

The workaround is to make `Normal` a special case at the end and set it
with `:highlight` until this bug is resolved.

Relates: #139 