### PR TITLE
`groups` option per style

### DIFF
--- a/doc/nightfox.txt
+++ b/doc/nightfox.txt
@@ -86,7 +86,9 @@ The individual components: |nightfox-palettes|, |nightfox-specs| and
       }
     })
     override.groups({
-      IncSearch = { bg = "palette.cyan" },
+      all = {
+        IncSearch = { bg = "palette.cyan" },
+      },
     })
 <
 
@@ -122,7 +124,9 @@ each component as seperate keys and calls the correct init/override function.
       }
     }
     local groups = {
-      IncSearch = { bg = "palette.cyan" },
+      all = {
+        IncSearch = { bg = "palette.cyan" },
+      },
     }
     require('nightfox').setup({
       options = options,
@@ -175,16 +179,18 @@ Note: If the resulting value of a template is a |nightfox-shade| then the
     
     -- Groups use specs as the template source
     local groups = {
-      -- The template path is parsed to [`syntax`, `string`]. This is like calling into a lua table like:
-      -- `spec.syntax.string`.
-      String = { fg = "syntax.string" },
+      all = {
+        -- The template path is parsed to [`syntax`, `string`]. This is like calling into a lua table like:
+        -- `spec.syntax.string`.
+        String = { fg = "syntax.string" },
     
-      -- By default nightfox links some groups together. `CursorColumn` is one of these groups. When overriding
-      -- Make sure `link` is cleared to `""` so that the link will be removed.
-      CursorColumn = { bg = "sel0", link = "" },
+        -- By default nightfox links some groups together. `CursorColumn` is one of these groups. When overriding
+        -- Make sure `link` is cleared to `""` so that the link will be removed.
+        CursorColumn = { bg = "sel0", link = "" },
     
-      -- Specs are used for the template. Specs have their palette's as a field that can be accessed
-      IncSearch = { bg = "palette.cyan" },
+        -- Specs are used for the template. Specs have their palette's as a field that can be accessed
+        IncSearch = { bg = "palette.cyan" },
+      },
     }
     
     require('nightfox').setup({ specs = specs, groups = groups })

--- a/lua/nightfox/group.lua
+++ b/lua/nightfox/group.lua
@@ -3,7 +3,12 @@ local template = require("nightfox.util.template")
 
 local M = {}
 
-function M.load(spec)
+local function override(groups, spec, ovr)
+  ovr = template.parse(ovr, spec)
+  return collect.deep_extend(groups, ovr)
+end
+
+function M.from(spec)
   local ovr = require("nightfox.override").groups
   local config = require("nightfox.config").options
 
@@ -24,7 +29,19 @@ function M.load(spec)
     end
   end
 
-  return collect.deep_extend(result, template.parse(ovr, spec))
+  local function apply_ovr(key, groups)
+    return ovr[key] and override(groups, spec, ovr[key]) or groups
+  end
+
+  result = apply_ovr("all", result)
+  result = apply_ovr(spec.palette.meta.name, result)
+
+  return result
+end
+
+function M.load(name)
+  name = name or require("nightfox.config").fox
+  return M.from(require("nightfox.spec").load(name))
 end
 
 return M

--- a/lua/nightfox/lib/compile.lua
+++ b/lua/nightfox/lib/compile.lua
@@ -32,7 +32,7 @@ end
 
 local function gen_nvim_highlight_block(lines, spec)
   local list = {}
-  local groups = require("nightfox.group").load(spec)
+  local groups = require("nightfox.group").from(spec)
   local normal = nil
   for name, values in pairs(groups) do
     -- HACK: This is because of the current issue with `nvim_set_hl` and Normal highlight.
@@ -78,7 +78,7 @@ end
 
 local function gen_viml_highlight_block(lines, spec)
   local list = {}
-  local groups = require("nightfox.group").load(spec)
+  local groups = require("nightfox.group").from(spec)
   for name, values in pairs(groups) do
     if values.link then
       table.insert(list, fmt([[highlight! link %s %s]], name, values.link))

--- a/lua/nightfox/main.lua
+++ b/lua/nightfox/main.lua
@@ -67,7 +67,7 @@ function M.load(opts)
     require(modname)
   else
     local spec = require("nightfox.spec").load(name)
-    local groups = require("nightfox.group").load(spec)
+    local groups = require("nightfox.group").from(spec)
 
     clear_hl()
     set_info(spec)
@@ -85,5 +85,7 @@ function M.load(opts)
     end
   end
 end
+
+M.load("nightfox")
 
 return M

--- a/lua/nightfox/util/deprication.lua
+++ b/lua/nightfox/util/deprication.lua
@@ -52,6 +52,29 @@ function M.check_deprication(opts)
   check_opt("colors", { replace = "palettes" })
   check_opt("hlgroups", { replace = "groups" })
 
+  if opts.groups then
+    local collect = require("nightfox.lib.collect")
+    local foxes = require("nightfox.palette").foxes
+    local invalid = false
+    for key, _ in pairs(opts.groups) do
+      print(key)
+      if not collect.contains(foxes, key) then
+        invalid = true
+        break
+      end
+    end
+
+    if invalid then
+      dep.write(
+        "  ",
+        { "groups", "WarningMsg" },
+        " is now per style. Use ",
+        { "all", "WarningMsg" },
+        " to apply for every style."
+      )
+    end
+  end
+
   M.checked_deprication = true
 end
 

--- a/readme.md
+++ b/readme.md
@@ -277,12 +277,19 @@ local specs = {
 --
 -- Just like `spec` groups support templates. This time the template is based on a spec object.
 local groups = {
-  -- By default nightfox links some groups together. `CursorColumn` is one of these groups. When overriding
-  -- Make sure `link` is cleared to `""` so that the link will be removed.
-  CursorColumn = { bg = "sel0", link = "" },
+  -- As with specs and palettes, the values defined under `all` will be applied to every style.
+  all = {
+    -- By default nightfox links some groups together. `CursorColumn` is one of these groups. When overriding
+    -- Make sure `link` is cleared to `""` so that the link will be removed.
+    CursorColumn = { bg = "sel0", link = "" },
 
-  -- Specs are used for the template. Specs have their palette's as a field that can be accessed
-  IncSearch = { bg = "palette.cyan" },
+    -- Specs are used for the template. Specs have their palette's as a field that can be accessed
+    IncSearch = { bg = "palette.cyan" },
+  },
+  nightfox = {
+    -- As with specs and palettes, a specific style's value will be used over the `all`'s value.
+    PmenuSel = { bg = "#73daca", fg = "bg0" },
+  },
 }
 
 require("nightfox").setup({ palettes = palettes, specs = specs, groups = groups })
@@ -333,7 +340,9 @@ require("nightfox").setup({
     },
   },
   groups = {
-    NormalNC = { fg = "fg1", bg = "inactive" }, -- Non-current windows
+    all = {
+      NormalNC = { fg = "fg1", bg = "inactive" }, -- Non-current windows
+    },
   },
 })
 ```

--- a/usage.md
+++ b/usage.md
@@ -64,7 +64,9 @@ override.specs({
   }
 })
 override.groups({
-  IncSearch = { bg = "palette.cyan" },
+  all = {
+    IncSearch = { bg = "palette.cyan" },
+  },
 })
 ```
 
@@ -98,7 +100,9 @@ local specs = {
   }
 }
 local groups = {
-  IncSearch = { bg = "palette.cyan" },
+  all = {
+    IncSearch = { bg = "palette.cyan" },
+  },
 }
 require('nightfox').setup({
   options = options,
@@ -145,16 +149,18 @@ local specs = {
 
 -- Groups use specs as the template source
 local groups = {
-  -- The template path is parsed to [`syntax`, `string`]. This is like calling into a lua table like:
-  -- `spec.syntax.string`.
-  String = { fg = "syntax.string" },
+  all = {
+    -- The template path is parsed to [`syntax`, `string`]. This is like calling into a lua table like:
+    -- `spec.syntax.string`.
+    String = { fg = "syntax.string" },
 
-  -- By default nightfox links some groups together. `CursorColumn` is one of these groups. When overriding
-  -- Make sure `link` is cleared to `""` so that the link will be removed.
-  CursorColumn = { bg = "sel0", link = "" },
+    -- By default nightfox links some groups together. `CursorColumn` is one of these groups. When overriding
+    -- Make sure `link` is cleared to `""` so that the link will be removed.
+    CursorColumn = { bg = "sel0", link = "" },
 
-  -- Specs are used for the template. Specs have their palette's as a field that can be accessed
-  IncSearch = { bg = "palette.cyan" },
+    -- Specs are used for the template. Specs have their palette's as a field that can be accessed
+    IncSearch = { bg = "palette.cyan" },
+  },
 }
 
 require('nightfox').setup({ specs = specs, groups = groups })


### PR DESCRIPTION
`palette` and `spec` can both be overridden per style but `group` was not. This change makes all override tables work the same.

### Old

```lua
require("nightfox").setup({
  groups = {
    CursorColumn = { bg = "sel0", link = "" },
    IncSearch = { bg = "palette.cyan" },
  },
})
```

### New

```lua
require("nightfox").setup({
  groups = {
    all = {
      CursorColumn = { bg = "sel0", link = "" },
      IncSearch = { bg = "palette.cyan" },
    },
  },
})
```