### PR TITLE
fix(setup): `group` override defaults `link` to ''

### DIFF
--- a/doc/nightfox.txt
+++ b/doc/nightfox.txt
@@ -184,9 +184,8 @@ Note: If the resulting value of a template is a |nightfox-shade| then the
         -- `spec.syntax.string`.
         String = { fg = "syntax.string" },
     
-        -- By default nightfox links some groups together. `CursorColumn` is one of these groups. When overriding
-        -- Make sure `link` is cleared to `""` so that the link will be removed.
-        CursorColumn = { bg = "sel0", link = "" },
+        -- If `link` is defined it will be applied over any other values defined
+        Whitespace = { link = "Comment" }
     
         -- Specs are used for the template. Specs have their palette's as a field that can be accessed
         IncSearch = { bg = "palette.cyan" },

--- a/lua/nightfox/override.lua
+++ b/lua/nightfox/override.lua
@@ -14,6 +14,14 @@ local function reset()
   store.has_override = false
 end
 
+local function check_link(tbl)
+  for _, style in pairs(tbl) do
+    for _, opts in pairs(style) do
+      opts.link = opts.link or ""
+    end
+  end
+end
+
 return setmetatable({ reset = reset }, {
   __index = function(_, value)
     if store[value] then
@@ -23,6 +31,9 @@ return setmetatable({ reset = reset }, {
 
   __newindex = function(_, key, value)
     if store[key] then
+      if key == "groups" then
+        check_link(value)
+      end
       store[key] = collect.deep_extend(store[key], value or {})
       store.has_override = true
     end

--- a/readme.md
+++ b/readme.md
@@ -279,9 +279,8 @@ local specs = {
 local groups = {
   -- As with specs and palettes, the values defined under `all` will be applied to every style.
   all = {
-    -- By default nightfox links some groups together. `CursorColumn` is one of these groups. When overriding
-    -- Make sure `link` is cleared to `""` so that the link will be removed.
-    CursorColumn = { bg = "sel0", link = "" },
+    -- If `link` is defined it will be applied over any other values defined
+    Whitespace = { link = "Comment" }
 
     -- Specs are used for the template. Specs have their palette's as a field that can be accessed
     IncSearch = { bg = "palette.cyan" },

--- a/usage.md
+++ b/usage.md
@@ -154,9 +154,8 @@ local groups = {
     -- `spec.syntax.string`.
     String = { fg = "syntax.string" },
 
-    -- By default nightfox links some groups together. `CursorColumn` is one of these groups. When overriding
-    -- Make sure `link` is cleared to `""` so that the link will be removed.
-    CursorColumn = { bg = "sel0", link = "" },
+    -- If `link` is defined it will be applied over any other values defined
+    Whitespace = { link = "Comment" }
 
     -- Specs are used for the template. Specs have their palette's as a field that can be accessed
     IncSearch = { bg = "palette.cyan" },


### PR DESCRIPTION
Instead of having to know that the highlight group you are overriding is
is linked and setting `link` = '' this is done automatically for you.