### PR TITLE
docs: Show full example of setup function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -169,6 +169,9 @@ require('nightfox').setup({
       -- ...
     },
   }
+  palettes = {},
+  specs = {},
+  groups = {},
 })
 
 -- setup must be called before loading


### PR DESCRIPTION
This change shows a setup function with all primary keys. This shows
that `options`, `palettes`, `specs`, and `groups` are all in the same
level in the table.

Relates: #192 