### PR TITLE
fix(syntax): Move diff* highlight groups under syntax

### DIFF
--- a/lua/nightfox/group/editor.lua
+++ b/lua/nightfox/group/editor.lua
@@ -76,16 +76,6 @@ function M.get(spec, config)
 
     -- debugPC         = {}, -- used for highlighting the current line in terminal-debug
     -- debugBreakpoint = {}, -- used for breakpoint colors in terminal-debug
-
-    -- Diff
-    diffAdded       = { fg = spec.git.add },
-    diffRemoved     = { fg = spec.git.removed },
-    diffChanged     = { fg = spec.git.changed },
-    diffOldFile     = { fg = spec.diag.warn },
-    diffNewFile     = { fg = spec.diag.hint },
-    diffFile        = { fg = spec.diag.info },
-    diffLine        = { fg = spec.syntax.builtin2 }, -- NOTE: not sure what this really is
-    diffIndexLine   = { fg = spec.syntax.preproc }, -- NOTE: not sure what this really is
  }
 end
 

--- a/lua/nightfox/group/syntax.lua
+++ b/lua/nightfox/group/syntax.lua
@@ -55,8 +55,8 @@ function M.get(spec, config)
     Error          = { fg = spec.diag.error }, -- (preferred) any erroneous construct
     Todo           = { fg = spec.bg1, bg = spec.diag.info }, -- (preferred) anything that needs extra attention; mostly the keywords TODO FIXME and XXX
 
-    qfLineNr     = { link = "lineNr" },
-    qfFileName   = { link = "Directory" },
+    qfLineNr       = { link = "lineNr" },
+    qfFileName     = { link = "Directory" },
 
     -- htmlH1       = {},
     -- htmlH2       = {},
@@ -74,6 +74,16 @@ function M.get(spec, config)
     -- markdownH1               = {},
     -- markdownH2               = {},
     -- markdownLinkText         = {},
+
+    -- Diff filetype (runtime/syntax/diff.vim)
+    diffAdded       = { fg = spec.git.add }, -- Added lines ("^+.*" | "^>.*")
+    diffRemoved     = { fg = spec.git.removed },-- Removed lines ("^-.*" | "^<.*")
+    diffChanged     = { fg = spec.git.changed }, -- Changed lines ("^! .*")
+    diffOldFile     = { fg = spec.diag.warn }, -- Old file that is being diff against
+    diffNewFile     = { fg = spec.diag.hint }, -- New file that is being compared to the old file
+    diffFile        = { fg = spec.diag.info }, -- The filename of the diff ("diff --git a/readme.md b/readme.md")
+    diffLine        = { fg = spec.syntax.builtin2 }, -- Line information ("@@ -169,6 +169,9 @@")
+    diffIndexLine   = { fg = spec.syntax.preproc }, -- Index line of diff ("index bf3763d..94f0f62 100644")
   }
 end
 


### PR DESCRIPTION
The diff* highlight groups are highlight groups that apply to the `diff`
filetype. This was confusing between DiffChange and diffChanged. Moving
to the syntax group file and comments should clarify the highlight
groups.

Relates: #192 