### PR TITLE
fix: Rename invalid autoload variable

### DIFF
--- a/autoload/lightline/colorscheme/carbonfox.vim
+++ b/autoload/lightline/colorscheme/carbonfox.vim
@@ -5,4 +5,4 @@ else
   let s:palette_str = luaeval('nightfox_vim')
   let s:p = eval(s:palette_str)
 endif
-let g:lightline#colorscheme#terafox#palette = lightline#colorscheme#fill(s:p)
+let g:lightline#colorscheme#carbonfox#palette = lightline#colorscheme#fill(s:p)


### PR DESCRIPTION
carbonfox was missing the support for lightline. I have fixed.

```vim
let g:lightline.colorscheme = 'carbonfox'
```
