### PR TITLE
fix(cache): config option to check user cached config

### DIFF
--- a/doc/nightfox.txt
+++ b/doc/nightfox.txt
@@ -248,6 +248,15 @@ module_default {bool}                  The default value of a module that has
                                        table.
 
 
+                                                        *nightfox-check_cache*
+
+check_cache {bool}                     If enabled nightfox will check a cached
+                                       hash of nightfox and the users config.
+                                       This should be disabled if your setup
+                                       uses `nix` and is stored in the
+                                       `/nix/store`. Default is `true`.
+
+
                                                              *nightfox-styles*
 
 styles {table}                         `styles` is a table that contains a list

--- a/lua/nightfox/config.lua
+++ b/lua/nightfox/config.lua
@@ -10,6 +10,7 @@ local defaults = {
   terminal_colors = true,
   dim_inactive = false,
   module_default = true,
+  check_cache = true,
   styles = {
     comments = "NONE",
     conditionals = "NONE",

--- a/lua/nightfox/fingerprint.lua
+++ b/lua/nightfox/fingerprint.lua
@@ -1,1 +1,1 @@
-return [[1a9f1d37367c9d57f0da0beb15efdf35d55661ba]]
+return [[14a66a1350d4e1110ade0d4faff8d79005361f6c]]

--- a/lua/nightfox/init.lua
+++ b/lua/nightfox/init.lua
@@ -25,6 +25,7 @@ end
 local M = {}
 
 function M.compile()
+  require("nightfox.util").ensure_dir(config.options.compile_path)
   local compiler = require("nightfox.lib." .. (is_vim and "vim." or "") .. "compiler")
   local foxes = require("nightfox.palette").foxes
   for _, style in ipairs(foxes) do
@@ -83,29 +84,36 @@ function M.setup(opts)
   end
 
   local util = require("nightfox.util")
-
-  local cached_stat_file = util.join_paths(config.options.compile_path, "stat")
-  local cached_stat = read_file(cached_stat_file)
-  local user_stat = vim.loop.fs_stat(debug.getinfo(2).source:sub(2))
-  user_stat = user_stat and tostring(user_stat.mtime.sec)
-
   local cached_fingerprint_file = util.join_paths(config.options.compile_path, "fingerprint")
-  local cached_fingerprint = read_file(cached_fingerprint_file) or ""
+  local cached_stat_file = util.join_paths(config.options.compile_path, "stat")
+  local cached_config_file = util.join_paths(config.options.compile_path, "config")
+
+  local cached_fingerprint = read_file(cached_fingerprint_file)
   local fingerprint = require("nightfox.fingerprint")
 
-  if not user_stat or not cached_stat or (cached_stat ~= user_stat) or (cached_fingerprint ~= fingerprint) then
-    util.ensure_dir(config.options.compile_path)
+  local should_compile = fingerprint ~= cached_fingerprint
+
+  local user_stat = nil
+  if config.options.check_cache then
+    local fstat = vim.loop.fs_stat(debug.getinfo(2).source:sub(2))
+    user_stat = fstat and tostring(fstat.mtime.sec)
+
+    if not should_compile then
+      should_compile = user_stat ~= read_file(cached_stat_file)
+    end
+  end
+
+  local config_hash = config.hash() + override.hash()
+  if not should_compile then
+    should_compile = tostring(config_hash) ~= read_file(cached_config_file)
+  end
+
+  if should_compile then
+    M.compile()
     write_file(cached_fingerprint_file, fingerprint)
+    write_file(cached_config_file, config_hash)
     if user_stat then
       write_file(cached_stat_file, user_stat)
-    end
-
-    local cached_config = util.join_paths(config.options.compile_path, "config")
-    local cached_hash = read_file(cached_config)
-    local current_config_hash = config.hash() + override.hash()
-    if cached_hash ~= tostring(current_config_hash) then
-      M.compile()
-      write_file(cached_config, current_config_hash)
     end
   end
 

--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,7 @@ require('nightfox').setup({
     terminal_colors = true, -- Set terminal colors (vim.g.terminal_color_*) used in `:terminal`
     dim_inactive = false,   -- Non focused panes set to alternative background
     module_default = true,  -- Default enable value for modules
+    check_cache = true,     -- Check cached setup. Disable if using the `/nix/store`
     styles = {              -- Style to be applied to different syntax groups
       comments = "NONE",    -- Value is any valid attr-list value `:help attr-list`
       conditionals = "NONE",

--- a/usage.md
+++ b/usage.md
@@ -196,6 +196,11 @@ A boolean value that if set will set the background of Non current windows to be
 
 The default value of a module that has not been overridden in the modules table.
 
+#### check_cache {bool}
+
+If enabled nightfox will check a cached hash of nightfox and the users config. This should be disabled if your setup
+uses `nix` and is stored in the `/nix/store`. Default is `true`.
+
 #### styles {table}
 
 `styles` is a table that contains a list of syntax components and their corresponding style. These styles can be any


### PR DESCRIPTION
This change adds an option whether nightfox checks the cached user stat. This should be disabled for `nix` users using the `/nix/store`.

Resolves: #253 