### PR TITLE
feat(cvd): support colorblind mode with daltonization

### DIFF
--- a/doc/nightfox.txt
+++ b/doc/nightfox.txt
@@ -14,6 +14,7 @@ Table of Contents                                 *nightfox-table-of-contents*
   - Group                                                     |nightfox-group|
   - Module                                                   |nightfox-module|
   - Color                                                     |nightfox-color|
+  - Colorblind                                           |nightfox-colorblind|
   - Compile                                                 |nightfox-compile|
   - Interactive                                         |nightfox-interactive|
 
@@ -295,6 +296,27 @@ inverse {table}                        `inverse` is a table that contains a
                                        of highlighting a search term with the
                                        default search color it will inverse the
                                        foureground and background colors.
+
+
+                                                         *nightfox-colorblind*
+
+colorblind {table}                     `colorblind` stores configuration
+                                       information for nightfox’s `color
+                                       vision deficiency` (cdv) mode. This
+                                       contains the following table:
+
+
+>
+    colorblind = {
+      enable = false,        -- Enable colorblind support
+      simulate_only = false, -- Only show simulated colorblind colors and not diff shifted
+      severity = {
+        protan = 0,          -- Severity [0,1] for protan (red)
+        deutan = 0,          -- Severity [0,1] for deutan (green)
+        tritan = 0,          -- Severity [0,1] for tritan (blue)
+      },
+    },
+<
 
 
                                                             *nightfox-modules*
@@ -702,6 +724,41 @@ color:rotate({value})                  Returns a new `Color` with {value} added
                                        be wrapped from `[0,360]`, meaning that
                                        if the value exceeds `360` it will be
                                        wrapped back to `0`.
+
+
+COLORBLIND                                               *nightfox-colorblind*
+
+For individuals with `color vision deficiency` (cvd), nightfox has implemented
+a `colorblind` mode to help enhance color contrast. This can be enabled with
+this option `colorblind.enable`.
+
+There are three types of `color vision deficiency` (cvd)
+
+│  Cone   │ Type │Week (trichromacy)│Missing (Dichromacy)│
+│L / Red  │Protan│Protanomaly       │Protanopia          │
+│M / Green│Deutan│Deuteranomaly     │Deuteranopia        │
+│S / Blue │Tritan│Tritanomaly       │Tritanopia          │
+
+
+The severity of `protan`, `deutan`, and `tritan` can be set individually.
+Severity is a value ranging from `0` to `1`. where `1` is full `dichromacy`
+(missing cone type).
+
+**Example:**
+
+>
+    require("nightfox").setup({
+      options = {
+        colorblind = {
+          enable = true,
+          severity = {
+            protan = 0.3,
+            deutan = 0.6,
+          },
+        },
+      },
+    })
+<
 
 
 COMPILE                                                     *nightfox-compile*

--- a/lua/nightfox/config.lua
+++ b/lua/nightfox/config.lua
@@ -10,6 +10,15 @@ local defaults = {
   terminal_colors = true,
   dim_inactive = false,
   module_default = true,
+  colorblind = {
+    enable = false,
+    simulate_only = false,
+    severity = {
+      protan = 0,
+      deutan = 0,
+      tritan = 0,
+    },
+  },
   styles = {
     comments = "NONE",
     conditionals = "NONE",

--- a/lua/nightfox/lib/colorblind.lua
+++ b/lua/nightfox/lib/colorblind.lua
@@ -1,0 +1,205 @@
+local bop = bit or bit32 or require("nightfox.lib.vim.bit")
+local fmt = string.format
+
+local linear_rgb_to_lms = {
+  { 0.17882, 0.43516, 0.04119 },
+  { 0.03456, 0.27155, 0.03867 },
+  { 0.00030, 0.00184, 0.01466 },
+}
+
+local lms_to_linear_rgb = {
+  { 8.09444, -13.05043, 11.67206 },
+  { -1.02485, 5.40193, -11.36147 },
+  { -0.03653, -0.41216, 69.35132 },
+}
+
+---Convert color hex string to srgb value [0-255]
+---@param str string
+---@return table
+local function from_str(str)
+  local s = str:lower():match("#?([a-f0-9]+)")
+  local n = tonumber(s, 16)
+  return {
+    bop.band(bop.rshift(n, 16), 0xff),
+    bop.band(bop.rshift(n, 8), 0xff),
+    bop.band(n, 0xff),
+  }
+end
+
+local function to_str(c)
+  return fmt("#%02x%02x%02x", c[1], c[2], c[3])
+end
+
+local function round_uint8(n)
+  return math.max(math.min(math.floor(n + 0.5), 0xff), 0)
+end
+
+local function clamp(v, min, max)
+  min, max = min or 0, max or 1
+  return math.max(math.min(v, max), min)
+end
+
+local function apply(t, f)
+  local r = {}
+  for i = 1, #t do
+    r[i] = f(t[i])
+  end
+  return r
+end
+
+local function mul(c, m)
+  return {
+    m[1][1] * c[1] + m[1][2] * c[2] + m[1][3] * c[3],
+    m[2][1] * c[1] + m[2][2] * c[2] + m[2][3] * c[3],
+    m[3][1] * c[1] + m[3][2] * c[2] + m[3][3] * c[3],
+  }
+end
+
+-- stylua: ignore
+local function srgb_to_lrgb(c)
+  return apply(c, function(x)
+      x = x / 0xff
+      if x <= 0 then return 0 end
+      if x >= 1 then return 1 end
+      if x < 0.04045 then return x / 12.92 end
+      return math.pow((x + 0.055) / 1.055, 2.4)
+    end
+  )
+end
+
+-- stylua: ignore
+local function lrgb_to_srgb(c)
+  return apply(c, function(a)
+    local f = function(x)
+      if x <= 0 then return 0 end
+      if x >= 1 then return 1 end
+      if x < 0.0031308 then return x * 12.92 end
+      return math.pow(x, 1.0 / 2.4) * 1.055 - 0.055
+    end
+    return round_uint8(f(a) * 0xff)
+  end)
+end
+
+local function lms_to_lrgb(lms)
+  return mul(lms, lms_to_linear_rgb)
+end
+
+local function lrgb_to_lms(lrgb)
+  return mul(lrgb, linear_rgb_to_lms)
+end
+
+local function apply_protan(lms, severity)
+  -- Viénot 1999.
+  lms[1] = (1 - severity) * lms[1] + severity * (2.02344 * lms[2] - 2.52580 * lms[3])
+end
+
+local function apply_deutan(lms, severity)
+  -- Viénot 1999.
+  lms[2] = (1 - severity) * lms[2] + severity * (0.49421 * lms[1] + 1.24827 * lms[3])
+end
+
+local function apply_tritan(lms, severity)
+  -- Brettel 1997.
+  -- Check which plane.
+  if (lms[1] * 0.34478 - lms[2] * 0.65518) >= 0 then
+    -- Plane 1 for tritanopia
+    lms[3] = (1 - severity) * lms[3] + severity * (-0.00257 * lms[1] + 0.05366 * lms[2])
+  else
+    -- Plane 2 for tritanopia
+    lms[3] = (1 - severity) * lms[3] + severity * (-0.06011 * lms[1] + 0.16299 * lms[2])
+  end
+end
+
+local function simulate(lms, kinds)
+  kinds = kinds or {}
+  local x = { lms[1], lms[2], lms[3] }
+
+  -- stylua: ignore start
+  if kinds.protan and kinds.protan > 0 then apply_protan(x, clamp(kinds.protan)) end
+  if kinds.deutan and kinds.deutan > 0 then apply_deutan(x, clamp(kinds.deutan)) end
+  if kinds.tritan and kinds.tritan > 0 then apply_tritan(x, clamp(kinds.tritan)) end
+  -- stylua: ignore end
+
+  return x
+end
+
+local function apply_difference_lrgb(orig_lrgb, sim_lrgb)
+  -- [0.0, 0.0, 0.0]
+  -- [0.7, 1.0, 0.0]
+  -- [0.7, 0.0, 1.0]
+
+  local e = {
+    orig_lrgb[1] - sim_lrgb[1],
+    orig_lrgb[2] - sim_lrgb[2],
+    orig_lrgb[3] - sim_lrgb[3],
+  }
+
+  return {
+    orig_lrgb[1],
+    orig_lrgb[2] + 0.7 * e[1] + 1 * e[2] + 0 * e[3],
+    orig_lrgb[3] + 0.7 * e[1] + 0 * e[2] + 1 * e[3],
+  }
+end
+
+local M = {}
+
+---@class CBKinds
+---@field protan number [0-1]
+---@field deutan number [0-1]
+---@field tritan number [0-1]
+
+---Simulate colorblindness based on the different severities
+---@param color string hex color
+---@param opts CBKinds
+function M.simulate(color, opts)
+  local lms = lrgb_to_lms(srgb_to_lrgb(from_str(color)))
+  local sim = simulate(lms, opts)
+  return to_str(lrgb_to_srgb(lms_to_lrgb(sim)))
+end
+
+---Apply Dantonize algorithm
+---@param color string hex color
+---@param opts CBKinds
+function M.daltonize(color, opts)
+  local lrgb = srgb_to_lrgb(from_str(color))
+  local lms = lrgb_to_lms(lrgb)
+  local sim = lms_to_lrgb(simulate(lms, opts))
+  -- P({ color = color, lrgb = lrgb_to_srgb(lrgb), sim = lrgb_to_srgb(sim) })
+  local diff = apply_difference_lrgb(lrgb, sim)
+  return to_str(lrgb_to_srgb(diff))
+end
+
+-- Keeping This here as by test case and what I was supposed to get
+--
+-- local srgb = from_str("#63cdcf")
+-- print(fmt(" srgb: r = %s, g = %s, b = %s", srgb[1], srgb[2], srgb[3]))
+-- local lrgb = srgb_to_lrgb(srgb)
+-- print(fmt(" lrgb: r = %s, g = %s, b = %s", lrgb[1], lrgb[2], lrgb[3]))
+-- local lms = lrgb_to_lms(lrgb)
+-- print(fmt("  lms: l = %s, m = %s, s = %s", lms[1], lms[2], lms[3]))
+-- local sim = simulate(lms, { protan = 1 })
+-- print(fmt("  sim: l = %s, m = %s, s = %s", sim[1], sim[2], sim[3]))
+-- local slrgb = lms_to_lrgb(sim)
+-- print(fmt("slrgb: r = %s, g = %s, b = %s", slrgb[1], slrgb[2], slrgb[3]))
+-- local dlrgb = apply_difference_lrgb(lrgb, slrgb)
+-- print(fmt("dlrgb: r = %s, g = %s, b = %s", dlrgb[1], dlrgb[2], dlrgb[3]))
+-- print(to_str(lrgb_to_srgb(dlrgb)))
+--
+-- Expected values
+--  srgb: r = 99, g = 205, b = 207
+--  lrgb: r = 0.124772, g = 0.610496, b = 0.623960
+--   lms: l = 0.313676, m = 0.194221, s = 0.010314
+--   sim: l = 0.366942, m = 0.194221, s = 0.010314
+-- slrgb: r = 0.555917, g = 0.555921, b = 0.621852
+-- dlrgb: r = 0.124772, g = 0.363269, b = 0.324267
+
+return M
+
+-- References:
+-- HUGE thanks to Nicolas Burrus and his DaltonLens project and website. This has been an
+-- invaluable resource in trying to understand colorblindness and cvd. His posts on understanding
+-- lms based cvd simulators helped make this topic comprehensible.
+-- https://daltonlens.org/
+-- https://daltonlens.org/understanding-cvd-simulation/
+-- https://github.com/DaltonLens/DaltonLens-Python
+-- https://github.com/DaltonLens/DaltonLens

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,7 @@
 
 - Supports both vim and neovim
 - Highly configurable with template overriding
+- [Colorblind](#colorblind) mode (daltonization, and simulation)
 - Support for multiple [plugins](#supported-plugins) and [status lines](#status-lines)
   - And many others should "just work"!
 - [Compile](#compile) user's configuration for fast startup times
@@ -93,12 +94,21 @@ require('nightfox').setup({
     -- Compiled file's destination location
     compile_path = vim.fn.stdpath("cache") .. "/nightfox",
     compile_file_suffix = "_compiled", -- Compiled file suffix
-    transparent = false,    -- Disable setting background
-    terminal_colors = true, -- Set terminal colors (vim.g.terminal_color_*) used in `:terminal`
-    dim_inactive = false,   -- Non focused panes set to alternative background
-    module_default = true,  -- Default enable value for modules
-    styles = {              -- Style to be applied to different syntax groups
-      comments = "NONE",    -- Value is any valid attr-list value `:help attr-list`
+    transparent = false,     -- Disable setting background
+    terminal_colors = true,  -- Set terminal colors (vim.g.terminal_color_*) used in `:terminal`
+    dim_inactive = false,    -- Non focused panes set to alternative background
+    module_default = true,   -- Default enable value for modules
+    colorblind = {
+      enable = false,        -- Enable colorblind support
+      simulate_only = false, -- Only show simulated colorblind colors and not diff shifted
+      severity = {
+        protan = 0,          -- Severity [0,1] for protan (red)
+        deutan = 0,          -- Severity [0,1] for deutan (green)
+        tritan = 0,          -- Severity [0,1] for tritan (blue)
+      },
+    },
+    styles = {               -- Style to be applied to different syntax groups
+      comments = "NONE",     -- Value is any valid attr-list value `:help attr-list`
       conditionals = "NONE",
       constants = "NONE",
       functions = "NONE",
@@ -384,6 +394,76 @@ print(vim.inspect(alt_bg:to_hsv()))
 There are a lot of useful functions to manipulate and work with colors in different color spaces.
 See [Usage](./usage.md#color) for more information on `Color`.
 
+## Colorblind
+
+For individuals with `color vision deficiency` (cvd), nightfox has implemented a `colorblind` mode to help enhance color
+contrast. This can be enabled with this option `colorblind.enable`.
+
+<details>
+<summary>Understanding cvd</summary>
+
+There are three types of cvd:
+
+- Protan (Red / L cones)
+- Deutan (Green / M cones)
+- Tritan (Blue / S cones)
+
+These are referred to as `protanomaly`, `deuteranomaly`, and `tritanomaly` for individuals that have all three cones
+(trichromats) but one is week (anomalous trichromacy).
+
+These can also be referred to as `protanopia`, `deuteranopia`, and `tritanopia`. This is for individuals that only have
+two cones (dichromats or dichromacy).
+
+| Cone      | Type   | Week (trichromacy) | Missing (Dichromacy) |
+| --------- | ------ | ------------------ | -------------------- |
+| L / Red   | Protan | Protanomaly        | Protanopia           |
+| M / Green | Deutan | Deuteranomaly      | Deuteranopia         |
+| S / Blue  | Tritan | Tritanomaly        | Tritanopia           |
+
+</details>
+
+### Configuring cvd
+
+Nightfox needs to simulate your cvd in order to shift colors correctly. This is done by setting your cvd type's severity
+level. Severity is a value between `0` and `1` where `1` is full dichromacy. You can also have multiple kinds of cvd
+configured at a time. Here is a full example:
+
+```lua
+require("nightfox").setup({
+  options = {
+    colorblind = {
+      enable = true,
+      severity = {
+        protan = 0.3,
+        deutan = 0.6,
+      },
+    },
+  },
+})
+```
+
+If you are looking for a way to self evaluate what severity factor to use, check out [daltonlens's][cb-self-eval] self
+evaluation article with interactive self evaluation Ishihasa plates.
+
+Another method would be to use the option `colorblind.simulate_only` option along with nightfox's
+[interactive](#interactive) mode. While nightfox is simulating cvd set a severity to 1. Now decrease the severity
+incrementally until you cannot perceive a difference in the change of colors.
+
+[cb-self-eval]: https://daltonlens.org/evaluating-cvd-simulation/#Generating-Ishihara-like-plates-for-self-evaluation
+
+### How does this work?
+
+This is accomplished by applying an algorithm called `Daltonization`. The process follows these steps:
+
+1. Simulate what a person with cvd would see
+1. Calculate the difference between original vs. simulated
+1. Shift the difference towards the visible spectrum of the cvd individual
+1. Correct original color by adding it to the corrected difference
+
+You can see the simulated colors instead of the corrected colors by setting the option `colorblind.simulate_only`.
+
+![cvd-example](https://user-images.githubusercontent.com/2746374/210025850-9a84b142-e989-4efa-9b55-5f7312013da3.gif)
+
 ## Compile
 
 Nightfox is a highly customizable and configurable colorscheme. This does however come at the cost of complexity and
@@ -552,6 +632,7 @@ There are [extra](./extra) configuration files for the following:
 - [coolers](https://coolers.co) (useful color information and palette tool)
 - [colorhexa](https://www.colorhexa.com/) (detailed color information)
 - [neogit](https://github.com/TimUntersberger/neogit/blob/b688a2c/lua/neogit/lib/color.lua) (base for color lib)
+- [daltonlens](https://daltonlens.org/) (understanding cvd simulations and research. Thanks [@nburrus](https://github.com/nburrus)!)
 
 ## References
 

--- a/usage.md
+++ b/usage.md
@@ -230,6 +230,23 @@ foreground and background colors instead of applying the normal highlight group.
 `match_paren`, `visual`, `search`. For an example if search is enabled instead of highlighting a search term with the
 default search color it will inverse the foureground and background colors.
 
+#### colorblind {table}
+
+`colorblind` stores configuration information for nightfox's `color vision deficiency` (cdv) mode. This contains the
+following table: 
+
+```lua
+colorblind = {
+  enable = false,        -- Enable colorblind support
+  simulate_only = false, -- Only show simulated colorblind colors and not diff shifted
+  severity = {
+    protan = 0,          -- Severity [0,1] for protan (red)
+    deutan = 0,          -- Severity [0,1] for deutan (green)
+    tritan = 0,          -- Severity [0,1] for tritan (blue)
+  },
+},
+```
+
 #### modules {table}
 
 `modules` store configuration information for various plugins and other neovim modules. A module can either be a boolean
@@ -530,6 +547,38 @@ or less saturated version depending of +/- v. {value} is Float [-100, 100].
 
 Returns a new `Color` with {value} added to the `hue` (`hsv`) of the current color. The resulting value of `hue` will be
 wrapped from `[0,360]`, meaning that if the value exceeds `360` it will be wrapped back to `0`.
+
+## Colorblind
+
+For individuals with `color vision deficiency` (cvd), nightfox has implemented a `colorblind` mode to help enhance color
+contrast. This can be enabled with this option `colorblind.enable`.
+
+There are three types of `color vision deficiency` (cvd)
+
+| Cone      | Type   | Week (trichromacy) | Missing (Dichromacy) |
+| --------- | ------ | ------------------ | -------------------- |
+| L / Red   | Protan | Protanomaly        | Protanopia           |
+| M / Green | Deutan | Deuteranomaly      | Deuteranopia         |
+| S / Blue  | Tritan | Tritanomaly        | Tritanopia           |
+
+The severity of `protan`, `deutan`, and `tritan` can be set individually. Severity is a value ranging from `0` to `1`.
+where `1` is full `dichromacy` (missing cone type).
+
+**Example:**
+
+```lua
+require("nightfox").setup({
+  options = {
+    colorblind = {
+      enable = true,
+      severity = {
+        protan = 0.3,
+        deutan = 0.6,
+      },
+    },
+  },
+})
+```
 
 ## Compile
 


### PR DESCRIPTION
This change adds support for a colorblind or color vision deficiency (cvd) mode. This mode implements a daltonization algorithm that shifts color to ranges that cvd people can see which helps create contrast with colors.

![colorblind-demo](https://user-images.githubusercontent.com/2746374/210025850-9a84b142-e989-4efa-9b55-5f7312013da3.gif)

Resolves: #89 