### PR TITLE
fix(module): use correct group names for illuminate.vim

### DIFF
--- a/lua/nightfox/group/modules/illuminate.lua
+++ b/lua/nightfox/group/modules/illuminate.lua
@@ -5,8 +5,9 @@ local M = {}
 function M.get(spec, config, opts)
   -- stylua: ignore
   return {
-    illuminatedWord    = { link = "LspReferenceText" },
-    illuminatedCurWord = { link = "LspReferenceText" },
+    illuminatedWordText  = { link = "LspReferenceText" },
+    illuminatedWordRead  = { link = "LspReferenceText" },
+    illuminatedWordWrite = { link = "LspReferenceText" },
   }
 end
 


### PR DESCRIPTION
New group names: https://github.com/RRethy/vim-illuminate/blob/master/plugin/illuminate.vim#L47-L49