### PR TITLE
feat: add support for ts-rainbow2

### DIFF
--- a/doc/nightfox.txt
+++ b/doc/nightfox.txt
@@ -508,6 +508,7 @@ Current list of modules are:
 - telescope
 - treesitter
 - tsrainbow
+- tsrainbow2
 - whichkey
 
 

--- a/lua/nightfox/config.lua
+++ b/lua/nightfox/config.lua
@@ -81,6 +81,7 @@ M.module_names = {
   "telescope",
   "treesitter",
   "tsrainbow",
+  "tsrainbow2",
   "whichkey",
 }
 

--- a/lua/nightfox/group/modules/tsrainbow2.lua
+++ b/lua/nightfox/group/modules/tsrainbow2.lua
@@ -1,0 +1,20 @@
+-- https://github.com/HiPhish/nvim-ts-rainbow2
+
+local M = {}
+
+function M.get(spec, config, opts)
+  local c = spec.palette
+
+  -- stylua: ignore
+  return {
+    TSRainbowBlue = { fg = c.blue.base },
+    TSRainbowCyan = { fg = c.cyan.base },
+    TSRainbowGreen = { fg = c.green.base },
+    TSRainbowOrange = { fg = c.orange.base },
+    TSRainbowRed = { fg = c.red.base },
+    TSRainbowViolet = { fg = c.magenta.base },
+    TSRainbowYellow = { fg = c.yellow.base },
+  }
+end
+
+return M

--- a/readme.md
+++ b/readme.md
@@ -457,6 +457,7 @@ There are a few things to note:
 - [symbols-outline.nvim](https://github.com/simrat39/symbols-outline.nvim)
 - [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
 - [nvim-ts-rainbow](https://github.com/p00f/nvim-ts-rainbow)
+- [nvim-ts-rainbow2](https://github.com/HiPhish/nvim-ts-rainbow2)
 - [which-key.nvim](https://github.com/folke/which-key.nvim)
 
 ## Status lines

--- a/usage.md
+++ b/usage.md
@@ -405,6 +405,7 @@ Current list of modules are:
 - telescope
 - treesitter
 - tsrainbow
+- tsrainbow2
 - whichkey
 
 ### Neovim specific modules


### PR DESCRIPTION
This adds support for the one of the new `ts-rainbow` maintained forks that is getting a rewrite and has different highlight groups: https://github.com/HiPhish/nvim-ts-rainbow2