### PR TITLE
perf(hash): optimize hash function

### DIFF
--- a/lua/nightfox/lib/hash.lua
+++ b/lua/nightfox/lib/hash.lua
@@ -3,19 +3,18 @@ local bitop = bit or bit32 or require("nightfox.lib.native_bit")
 -- https://theartincode.stanis.me/008-djb2/
 local function djb2(s)
   local h = 5381
-  local t = { string.byte(s, 1, #s) }
-  for i = 1, #t do
-    h = bitop.lshift(h, 5) + t[i] -- h * 33 + c
+  for i = 1, #s do
+    h = bitop.lshift(h, 5) + string.byte(s, i) -- h * 33 + c
   end
   return h
 end
 
--- Reference: https://github.com/catppuccin/nvim/blob/151b5f6aa74f08a707a7862519bdc38bb2b9f505/lua/catppuccin/lib/hashing.lua
+-- Reference: https://github.com/catppuccin/nvim/blob/60f8f40df0db92b5715642b3ea7074380c4b7995/lua/catppuccin/lib/hashing.lua
 local function hash(x)
   local t = type(x)
   if t == "table" then
     local h = 0
-    for k, v in pairs(x) do
+    for k, v in next, x do
       h = bitop.bxor(h, djb2(k .. hash(v)))
     end
     return h


### PR DESCRIPTION
~~This pr optimizes the hash function used to compute checksums for cached values. This is achieved by serializing a table into a minimum string representation and then performing the `dj2b` hashing algorithm on this string.~~

This pr optimizes the dj2b function by removing `{ string.byte }` because it is only faster when the string is very long, which isn't the case for configurations

Benchmarks were on both main and perf branch.

```lua
local t = require("nightfox.config").options
local hash = require("nightfox.lib.hash")

local function bench(msg, f, iter)
  iter = iter or 1000
  local sum = 0
  for _ = 1, iter do
    local start = vim.loop.hrtime()
    f()
    sum = sum + (vim.loop.hrtime() - start)
  end
  print(msg, sum / iter / 1000000)
end

bench("perf", function()
  hash(t)
end, 10000)
```


### Results

| branch | time ms |
| ------- | -------- |
| main | 0.4782018948 |
| perf | 0.0033633242 |