### PR TITLE
fix(cache): move setup guard before load call

### DIFF
--- a/lua/nightfox/init.lua
+++ b/lua/nightfox/init.lua
@@ -41,6 +41,7 @@ end
 
 -- Avold g:colors_name reloading
 local lock = false
+local did_setup = false
 
 function M.load(opts)
   if lock then
@@ -62,12 +63,12 @@ function M.load(opts)
     f = loadfile(compiled_file)
   end
 
+  ---@diagnostic disable-next-line: need-check-nil
   f()
 
   lock = false
 end
 
-local did_setup = false
 function M.setup(opts)
   did_setup = true
   opts = opts or {}


### PR DESCRIPTION
Having the `did_setup` value after the load function was causing cache misses as the flag was not set even when calling setup before load.

Resolves: #330 