### PR TITLE
fix(extra): zellij black and white set to bg3/fg3

### DIFF
--- a/extra/zellij/nightfox.kdl
+++ b/extra/zellij/nightfox.kdl
@@ -2,58 +2,6 @@
 // https://github.com/edeneast/nightfox.nvim
 
 themes {
-  terafox {
-    bg "#152528"
-    fg "#e6eaea"
-    red "#e85c51"
-    green "#7aa4a1"
-    blue "#5a93aa"
-    yellow "#fda47f"
-    magenta "#ad5c7c"
-    orange "#ff8349"
-    cyan "#a1cdd8"
-    black "#2f3239"
-    white "#ebebeb"
-  }
-  duskfox {
-    bg "#232136"
-    fg "#e0def4"
-    red "#eb6f92"
-    green "#a3be8c"
-    blue "#569fba"
-    yellow "#f6c177"
-    magenta "#c4a7e7"
-    orange "#ea9a97"
-    cyan "#9ccfd8"
-    black "#393552"
-    white "#e0def4"
-  }
-  nightfox {
-    bg "#192330"
-    fg "#cdcecf"
-    red "#c94f6d"
-    green "#81b29a"
-    blue "#719cd6"
-    yellow "#dbc074"
-    magenta "#9d79d6"
-    orange "#f4a261"
-    cyan "#63cdcf"
-    black "#393b44"
-    white "#dfdfe0"
-  }
-  nordfox {
-    bg "#2e3440"
-    fg "#cdcecf"
-    red "#bf616a"
-    green "#a3be8c"
-    blue "#81a1c1"
-    yellow "#ebcb8b"
-    magenta "#b48ead"
-    orange "#c9826b"
-    cyan "#88c0d0"
-    black "#3b4252"
-    white "#e5e9f0"
-  }
   carbonfox {
     bg "#161616"
     fg "#f2f4f8"
@@ -64,8 +12,8 @@ themes {
     magenta "#be95ff"
     orange "#3ddbd9"
     cyan "#33b1ff"
-    black "#282828"
-    white "#dfdfe0"
+    black "#353535"
+    white "#7b7c7e"
   }
   dawnfox {
     bg "#faf4ed"
@@ -77,8 +25,8 @@ themes {
     magenta "#907aa9"
     orange "#d7827e"
     cyan "#56949f"
-    black "#575279"
-    white "#e5e9f0"
+    black "#ebdfe4"
+    white "#a8a3b3"
   }
   dayfox {
     bg "#f6f2ee"
@@ -90,7 +38,59 @@ themes {
     magenta "#6e33ce"
     orange "#955f61"
     cyan "#287980"
-    black "#352c24"
-    white "#f2e9e1"
+    black "#d3c7bb"
+    white "#824d5b"
+  }
+  duskfox {
+    bg "#232136"
+    fg "#e0def4"
+    red "#eb6f92"
+    green "#a3be8c"
+    blue "#569fba"
+    yellow "#f6c177"
+    magenta "#c4a7e7"
+    orange "#ea9a97"
+    cyan "#9ccfd8"
+    black "#373354"
+    white "#6e6a86"
+  }
+  nightfox {
+    bg "#192330"
+    fg "#cdcecf"
+    red "#c94f6d"
+    green "#81b29a"
+    blue "#719cd6"
+    yellow "#dbc074"
+    magenta "#9d79d6"
+    orange "#f4a261"
+    cyan "#63cdcf"
+    black "#29394f"
+    white "#71839b"
+  }
+  nordfox {
+    bg "#2e3440"
+    fg "#cdcecf"
+    red "#bf616a"
+    green "#a3be8c"
+    blue "#81a1c1"
+    yellow "#ebcb8b"
+    magenta "#b48ead"
+    orange "#c9826b"
+    cyan "#88c0d0"
+    black "#444c5e"
+    white "#7e8188"
+  }
+  terafox {
+    bg "#152528"
+    fg "#e6eaea"
+    red "#e85c51"
+    green "#7aa4a1"
+    blue "#5a93aa"
+    yellow "#fda47f"
+    magenta "#ad5c7c"
+    orange "#ff8349"
+    cyan "#a1cdd8"
+    black "#254147"
+    white "#587b7b"
   }
 }

--- a/lua/nightfox/extra/zellij.lua
+++ b/lua/nightfox/extra/zellij.lua
@@ -11,9 +11,15 @@ function M.generate(specs)
 themes {
 ]]
 
-  for _, spec in pairs(specs) do
+  local keys = vim.tbl_keys(specs)
+  table.sort(keys)
+
+  for _, name in ipairs(keys) do
+    local spec = specs[name]
+    spec.name = name
+
     local content = [[
-  ${palette.meta.name} {
+  ${name} {
     bg "${bg1}"
     fg "${fg1}"
     red "${palette.red}"
@@ -23,12 +29,13 @@ themes {
     magenta "${palette.magenta}"
     orange "${palette.orange}"
     cyan "${palette.cyan}"
-    black "${palette.black}"
-    white "${palette.white}"
+    black "${bg3}"
+    white "${fg3}"
   }
 ]]
     lines[#lines + 1] = template.parse_template_str(content, spec)
   end
+
   lines[#lines + 1] = "}"
 
   return table.concat(lines)


### PR DESCRIPTION
Zellij's theme uses black for the background panels. This make it more in line with the rest of the themes

Here are some examples

<img width="1883" alt="Screenshot 2023-04-20 at 9 51 45 PM" src="https://user-images.githubusercontent.com/2746374/233523223-9f36a5a1-ef4d-4c92-a0d3-dee9458d68fc.png">
<img width="1883" alt="Screenshot 2023-04-20 at 9 52 35 PM" src="https://user-images.githubusercontent.com/2746374/233523236-47000c4a-acfa-4c7f-b6dc-13eef9c0f4f1.png">
<img width="1883" alt="Screenshot 2023-04-20 at 9 53 35 PM" src="https://user-images.githubusercontent.com/2746374/233523242-656b54aa-f06a-4d0d-891e-8b44e7127dcb.png">
