### PR TITLE
fix(syntax): Fix highlight for json labels

### DIFF
--- a/lua/nightfox/group/modules/treesitter.lua
+++ b/lua/nightfox/group/modules/treesitter.lua
@@ -117,7 +117,7 @@ If you want to stay on nvim 0.7, disable the module, or pin to commit 15f3b5837a
     -- Language specific -------------------------------------------------------
 
     -- json
-    ["@label.json"]             = { fg = spec.func }, -- For labels: label: in C and :label: in Lua.
+    ["@label.json"]             = { fg = syn.func }, -- For labels: label: in C and :label: in Lua.
 
     -- lua
     ["@constructor.lua"]        = { fg = spec.fg2 }, -- For constructor calls and definitions: = { } in Lua, and Java constructors.


### PR DESCRIPTION
Within the Treesitter module, the group `@label.json` was previously using `fg = spec.func` to color JSON labels as functions.

However the spec `func` is nested in `spec.syntax.func` not in `spec.func`, which caused incorrect highlighting of JSON labels.

By using `syn.func`, which correctly points to `spec.syntax.func`, the issue is now resolved.

### Before commit
![json_label_highlight_bad](https://github.com/EdenEast/nightfox.nvim/assets/11842923/9cead330-2c1b-427d-834f-a54765ef1624)

### After commit
![json_label_highlight_good](https://github.com/EdenEast/nightfox.nvim/assets/11842923/77026b5e-e6df-4426-a4ff-65b82d31e8c0)

