### PR TITLE
Add rainbow-delimiters module

### DIFF
--- a/lua/nightfox/config.lua
+++ b/lua/nightfox/config.lua
@@ -92,6 +92,7 @@ M.module_names = {
   "notify",
   "nvimtree",
   "pounce",
+  "rainbow_delimiters",
   "signify",
   "sneak",
   "symbol_outline",

--- a/lua/nightfox/group/modules/rainbow_delimiters.lua
+++ b/lua/nightfox/group/modules/rainbow_delimiters.lua
@@ -1,0 +1,20 @@
+-- https://gitlab.com/HiPhish/rainbow-delimiters.nvim
+
+local M = {}
+
+function M.get(spec, config, opts)
+  local c = spec.palette
+
+  -- stylua: ignore
+  return {
+    RainbowDelimiterRed = { fg = c.red.base },
+    RainbowDelimiterYellow = { fg = c.yellow.base },
+    RainbowDelimiterBlue = { fg = c.blue.base },
+    RainbowDelimiterOrange = { fg = c.orange.base },
+    RainbowDelimiterGreen = { fg = c.green.base },
+    RainbowDelimiterViolet = { fg = c.pink.base },
+    RainbowDelimiterCyan = { fg = c.cyan.base },
+  }
+end
+
+return M

--- a/readme.md
+++ b/readme.md
@@ -544,6 +544,7 @@ There are a few things to note:
 - [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
 - [nvim-ts-rainbow](https://github.com/p00f/nvim-ts-rainbow)
 - [nvim-ts-rainbow2](https://github.com/HiPhish/nvim-ts-rainbow2)
+- [rainbow-delimiters](https://gitlab.com/HiPhish/rainbow-delimiters.nvim)
 - [which-key.nvim](https://github.com/folke/which-key.nvim)
 
 ## Status lines

--- a/usage.md
+++ b/usage.md
@@ -419,6 +419,7 @@ Current list of modules are:
 - notify
 - nvimtree
 - pounce
+- rainbow_delimiters
 - signify
 - sneak
 - symbol_outline


### PR DESCRIPTION
Adds support for [rainbow-delimiters](https://gitlab.com/HiPhish/rainbow-delimiters.nvim), which replaces tsrainbow2.

I'm marking this as draft as I've not been able to successfully `make docgen` due to the following, which I don't know enough about the moving parts to fix:

```
nightfox.nvim % make docgen
Error running Lua:
misc/panvimdoc/scripts/panvimdoc.lua:198: attempt to perform arithmetic on a nil value (field 'incrementheadinglevelby')
stack traceback:
        while rendering Pandoc
stack traceback:
make: *** [docgen] Error 84
```

(I just did `brew install pandoc` to install it, hopefully that's correct.)

If you can handle that part, this is hopefully good to go.