### PR TITLE
Fixes for Vim 9.0.1894 + liblua 5.1

### DIFF
--- a/lua/nightfox/lib/vim/compiler.lua
+++ b/lua/nightfox/lib/vim/compiler.lua
@@ -19,7 +19,7 @@ function M.compile(opts)
     fmt(
       [[
 return string.dump(function()
-vim.command([[
+vim.command(]] .. '[[' .. [[
 if exists("colors_name")
   hi clear
 endif

--- a/lua/nightfox/lib/vim/compiler.lua
+++ b/lua/nightfox/lib/vim/compiler.lua
@@ -71,7 +71,7 @@ set background=%s]],
 
   file = io.open(output_file, "wb")
 
-  local ld = load or loadstring -- loadstring == 5.1, load >= 5.2
+  local ld = loadstring or load -- loadstring == 5.1, load >= 5.2
   local f = ld(table.concat(lines, "\n"), "=")
   if not f then
     local tmpfile = util.join_paths(util.get_tmp_dir(), "nightfox_error.lua")

--- a/lua/nightfox/lib/vim/compiler.lua
+++ b/lua/nightfox/lib/vim/compiler.lua
@@ -80,7 +80,7 @@ set background=%s]],
 You can open '%s' for debugging.
 
 If you think this is a bug, kindly open an issue and attach '%s' file.
-Bellow is the error message:
+Below is the error message:
 ]],
       tmpfile,
       tmpfile


### PR DESCRIPTION
Hi there! The Vim I use under current Debian testing was showing a few errors since 741366250cff3aa7b85d6588ffc9db60ebbfdcc9. I'm not great with Lua, but I like this colour scheme enough to attempt a fix! Let me know if anything looks wrong with this patch.


Looks like liblua 5.1 deprecates `[[` inside a `[[` ... `]]` string. 01962d86527a8bb70b064caf7421d563582765a2 fixes an error message there. Fixes the error message

```
Error detected while processing /home/andrewc/.vimrc[1321]../home/andrewc/.vimrc.local[13]../home/andrewc/Configs/Dotfiles/vim/.vim/bundle/nightfox.nvim/colors/dawnfox.vim
line    9:
error loading module 'nightfox.lib.vim.compiler' from file '/home/andrewc/Configs/Dotfiles/vim/.vim/bundle/nightfox.nvim/lua/nightfox/lib/vim/compiler.lua':
^I...Dotfiles/vim/.vim/bundle/nightfox.nvim/lua/nightfox/lib/vim/compiler.lua:22: nesting of [[...]] is deprecated near '['
```


I think the backwards compatibility code for `load` vs `loadstring` in main is in the wrong order. Both functions exist in both 5.1 and 5.2, but if 5.1 tries to use load, and it will, you get

```
Error detected while processing /home/andrewc/.vimrc[1321]../home/andrewc/.vimrc.local[13]../home/andrewc/Configs/Dotfiles/vim/.vim/bundle/nightfox.nvim/colors/dawnfox.vim
line    9:
...ndle/nightfox.nvim/lua/nightfox/lib/vim/compiler.lua:75: bad argument #1 to 'ld' (function expected, got string)
```

Perhaps it makes sense to test for `loadstring` first, even if it is deprecated in 5.2. That means it should still work, I hope. If this fails under 5.2, then duck typing won't fix this. It'll need to test `_VERSION` or something.

(The failure conditions breaks the theme and makes all the colours go screwy, so I'm motivated to get this right)