### PR TITLE
fix(groups): differentiate between active button with lazy.nvim

### DIFF
--- a/doc/nightfox.txt
+++ b/doc/nightfox.txt
@@ -513,6 +513,7 @@ Current list of modules are:
 - hop
 - illuminate
 - indent_blanklines
+- lazy.nvim
 - leap
 - lightspeed
 - lsp_saga

--- a/flake.lock
+++ b/flake.lock
@@ -1,15 +1,12 @@
 {
   "nodes": {
     "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -20,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694959747,
-        "narHash": "sha256-CXQ2MuledDVlVM5dLC4pB41cFlBWxRw4tCBsFrq3cRk=",
+        "lastModified": 1668326430,
+        "narHash": "sha256-fJEsHe+lzFf3qcQVTTdK9jqRtUUVXH71tdfgjcKJNpA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "970a59bd19eff3752ce552935687100c46e820a5",
+        "rev": "fc07622617a373a742ed96d4dd536849d4bc1ec6",
         "type": "github"
       },
       "original": {
@@ -38,21 +35,6 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/lua/nightfox/config.lua
+++ b/lua/nightfox/config.lua
@@ -77,6 +77,7 @@ M.module_names = {
   "hop",
   "illuminate",
   "indent_blankline",
+  "lazy",
   "leap",
   "lightspeed",
   "lsp_saga",

--- a/lua/nightfox/group/modules/lazy.lua
+++ b/lua/nightfox/group/modules/lazy.lua
@@ -1,0 +1,11 @@
+local M = {}
+
+function M.get(spec, config, opts)
+  return {
+    LazyButtonActive = { link = "TabLineSel" },
+    LazyDimmed = { link = "LineNr" },
+    LazyProp = { link = "LineNr" },
+  }
+end
+
+return M

--- a/readme.md
+++ b/readme.md
@@ -529,6 +529,7 @@ There are a few things to note:
 - [lspsaga.nvim](https://github.com/glepnir/lspsaga.nvim)
 - [lsp-trouble.nvim](https://github.com/simrat39/lsp-trouble.nvim)
 - [indent-blankline.nvim](https://github.com/lukas-reineke/indent-blankline.nvim)
+- [lazy.nvim](https://github.com/folke/lazy.nvim)
 - [mini.nvim](https://github.com/echasnovski/mini.nvim)
 - [modes.nvim](https://github.com/mvllow/modes.nvim)
 - [nvim-navic](https://github.com/SmiteshP/nvim-navic)

--- a/usage.md
+++ b/usage.md
@@ -405,6 +405,7 @@ Current list of modules are:
 - hop
 - illuminate
 - indent_blanklines
+- lazy.nvim
 - leap
 - lightspeed
 - lsp_saga


### PR DESCRIPTION
## Buttons

Lazy.nvim used CursorLine and VisualSelect to differentiate between active and non-active buttons at the top of lazy's ui. These are the same styles in nightfox.

This was overridden to help make active button visually unique.

### Before

![image](https://github.com/EdenEast/nightfox.nvim/assets/2746374/9f3508ae-9ddd-4243-833b-4827489e6c0b)

### After

![image](https://github.com/EdenEast/nightfox.nvim/assets/2746374/e11b946b-2b03-430c-99f3-326c9e83a4dd)

## Dimmed

The Dimmed and Prop highlight groups were linked to `Conceal`. As this makes the text too concealed on the darker background this was changed to be slightly more contrasting while keeping then still dimmed.

### Before

![image](https://github.com/EdenEast/nightfox.nvim/assets/2746374/8bc6eea9-729a-441d-ae51-13eadf22450c)

### After

![image](https://github.com/EdenEast/nightfox.nvim/assets/2746374/3ef14ee8-9143-45b2-8370-b201ec4ed9d5)
