### PR TITLE
fix(group): WinSeperator defined along side VertSplit

### DIFF
--- a/lua/nightfox/group/editor.lua
+++ b/lua/nightfox/group/editor.lua
@@ -24,7 +24,8 @@ function M.get(spec, config)
     -- TermCursor      = {}, -- cursor in a focused terminal
     -- TermCursorNC    = {}, -- cursor in an unfocused terminal
     ErrorMsg        = { fg = spec.diag.error }, -- error messages on the command line
-    VertSplit       = { fg = spec.bg0 }, -- the column separating vertically split windows
+    WinSeperator    = { fg = spec.bg0 }, -- the column separating vertically split windows
+    VertSplit       = { link = "WinSeperator" }, -- the column separating vertically split windows
     Folded          = { fg = spec.fg3, bg = spec.bg2 }, -- line used for closed folds
     FoldColumn      = { fg = spec.fg3 }, -- 'foldcolumn'
     SignColumn      = { fg = spec.fg3 }, -- column where |signs| are displayed


### PR DESCRIPTION
Relates to default colorscheme change in neovim [#26334](https://github.com/neovim/neovim/pull/26334)

Resolves: #386 