### PR TITLE
Set the background highlight of WhichKey to "NormalFloat"

### DIFF
--- a/lua/nightfox/group/modules/whichkey.lua
+++ b/lua/nightfox/group/modules/whichkey.lua
@@ -10,7 +10,7 @@ function M.get(spec, config, opts)
     WhichKeyDesc      = { link = "Keyword" },
     WhichKeySeperator = { link = "Comment" },
     WhichKeySeparator = { link = "Comment" },
-    WhichKeyFloat     = { bg = spec.bg0 },
+    WhichKeyFloat     = { link = "NormalFloat" },
     WhichKeyValue     = { link = "Comment" },
   }
 end


### PR DESCRIPTION
The WhichKey window should be treated as a floating window, which benefits users with transparent backgrounds without affecting the display of no-transparent ones.

### opaque
![no transparent](https://github.com/EdenEast/nightfox.nvim/assets/31800073/c8bef531-8513-4ce1-8238-e60dbfece09e)

### transparent

![image](https://github.com/EdenEast/nightfox.nvim/assets/31800073/fb7f56d9-9121-44ab-a109-e2b08d68ea0d)

What's more, the original ` spec.bg0 ` is not conducive to the user's simple customization of this highlight

thus，user can simplely use ` NormalFloat = { fg = "fg1", bg = "NONE", }, ` to set most of the float windows to transparent