### PR TITLE
fix: link to correct Function highlight group

### DIFF
--- a/lua/nightfox/group/modules/treesitter.lua
+++ b/lua/nightfox/group/modules/treesitter.lua
@@ -47,7 +47,7 @@ function M.get(spec, config, opts)
     ["@property"] = { fg = syn.field }, -- the key in key/value pairs
 
     -- Functions --------------------------------------------------------------
-    ["@function"] = { link = "Functions" }, -- function definitions
+    ["@function"] = { link = "Function" }, -- function definitions
     ["@function.builtin"] = { fg = syn.builtin0, style = stl.functions }, -- built-in functions
     -- ["@function.call"] = { }, -- function calls
     ["@function.macro"] = { fg = syn.builtin0, style = stl.functions }, -- preprocessor macros


### PR DESCRIPTION
The `Function` highlight group exists and is defined here
https://github.com/EdenEast/nightfox.nvim/blob/7e9487875dc5f69a2fd6f60d3a3ef4fb457b57c1/lua/nightfox/group/syntax.lua#L19

I assume this was just a typo in the recent Great Migration of Treesitter Highlights