### PR TITLE
documentation: Change spelling of "week" to "weak"

### DIFF
--- a/doc/nightfox.txt
+++ b/doc/nightfox.txt
@@ -746,7 +746,7 @@ this option `colorblind.enable`.
 
 There are three types of `color vision deficiency` (cvd)
 
-│  Cone   │ Type │Week (trichromacy)│Missing (Dichromacy)│
+│  Cone   │ Type │Weak (trichromacy)│Missing (Dichromacy)│
 │L / Red  │Protan│Protanomaly       │Protanopia          │
 │M / Green│Deutan│Deuteranomaly     │Deuteranopia        │
 │S / Blue │Tritan│Tritanomaly       │Tritanopia          │

--- a/readme.md
+++ b/readme.md
@@ -413,12 +413,12 @@ There are three types of cvd:
 - Tritan (Blue / S cones)
 
 These are referred to as `protanomaly`, `deuteranomaly`, and `tritanomaly` for individuals that have all three cones
-(trichromats) but one is week (anomalous trichromacy).
+(trichromats) but one is weak (anomalous trichromacy).
 
 These can also be referred to as `protanopia`, `deuteranopia`, and `tritanopia`. This is for individuals that only have
 two cones (dichromats or dichromacy).
 
-| Cone      | Type   | Week (trichromacy) | Missing (Dichromacy) |
+| Cone      | Type   | Weak (trichromacy) | Missing (Dichromacy) |
 | --------- | ------ | ------------------ | -------------------- |
 | L / Red   | Protan | Protanomaly        | Protanopia           |
 | M / Green | Deutan | Deuteranomaly      | Deuteranopia         |

--- a/usage.md
+++ b/usage.md
@@ -567,7 +567,7 @@ contrast. This can be enabled with this option `colorblind.enable`.
 
 There are three types of `color vision deficiency` (cvd)
 
-| Cone      | Type   | Week (trichromacy) | Missing (Dichromacy) |
+| Cone      | Type   | Weak (trichromacy) | Missing (Dichromacy) |
 | --------- | ------ | ------------------ | -------------------- |
 | L / Red   | Protan | Protanomaly        | Protanopia           |
 | M / Green | Deutan | Deuteranomaly      | Deuteranopia         |


### PR DESCRIPTION
I noticed this while exploring the colorblind mode (thanks for that, by the way!). 