### PR TITLE
Add NotifyBackground missing highlight

### DIFF
--- a/lua/nightfox/group/modules/notify.lua
+++ b/lua/nightfox/group/modules/notify.lua
@@ -24,11 +24,12 @@ function M.get(spec, config, opts)
     NotifyDEBUGTitle = { fg = spec.diag.hint },
     NotifyTRACETitle = { fg = spec.syntax.comment },
 
-    NotifyERRORIcon = { link = "NotifyERRORTitle" },
-    NotifyWARNIcon  = { link = "NotifyWARNTitle" },
-    NotifyINFOIcon  = { link = "NotifyINFOTitle" },
-    NotifyDEBUGIcon = { link = "NotifyDEBUGTitle" },
-    NotifyTRACEIcon = { link = "NotifyTRACETitle" },
+    NotifyERRORIcon  = { link = "NotifyERRORTitle" },
+    NotifyWARNIcon   = { link = "NotifyWARNTitle" },
+    NotifyINFOIcon   = { link = "NotifyINFOTitle" },
+    NotifyDEBUGIcon  = { link = "NotifyDEBUGTitle" },
+    NotifyTRACEIcon  = { link = "NotifyTRACETitle" },
+    NotifyBackground = { link = "NormalFloat" },
   }
 end
 


### PR DESCRIPTION
Summary
----
This adds a missing highlight for notify-nvim, specifically `NotifyBackground` (linked to `NormalFloat`). Without this we receive a warning message from nvim-notify stating that `NotifyBackground` is unset for the colorscheme.