### PR TITLE
Added custom styling for preprocessor macros

### DIFF
--- a/doc/nightfox.txt
+++ b/doc/nightfox.txt
@@ -266,6 +266,7 @@ options.styles {table}                 `styles` is a table that contains a list
 - keywords
 - numbers
 - operators
+- preprocs
 - strings
 - types
 - variables

--- a/lua/nightfox/config.lua
+++ b/lua/nightfox/config.lua
@@ -27,6 +27,7 @@ local defaults = {
     keywords = "NONE",
     numbers = "NONE",
     operators = "NONE",
+    preprocs = "NONE",
     strings = "NONE",
     types = "NONE",
     variables = "NONE",

--- a/lua/nightfox/group/syntax.lua
+++ b/lua/nightfox/group/syntax.lua
@@ -27,7 +27,7 @@ function M.get(spec, config)
     Keyword        = { fg = syn.keyword, style = stl.keywords }, -- any other keyword
     Exception      = { link = "Keyword" }, -- try, catch, throw
 
-    PreProc        = { fg = syn.preproc }, -- (preferred) generic Preprocessor
+    PreProc        = { fg = syn.preproc, style = stl.preprocs }, -- (preferred) generic Preprocessor
     Include        = { link = "PreProc" }, -- preprocessor #include
     Define         = { link = "PreProc" }, -- preprocessor #define
     Macro          = { link = "PreProc" }, -- same as Define

--- a/usage.md
+++ b/usage.md
@@ -208,6 +208,7 @@ combination of |highlight-args|. The list of syntax components are:
 - keywords
 - numbers
 - operators
+- preprocs
 - strings
 - types
 - variables


### PR DESCRIPTION
The "PreProc" category has a group assigned to changing syntax colors, but not the style (bold, italic, etc). This is really useful for systems languages like C or Rust. For example, I cannot get `use` to show as bold when writing Rust.
![image](https://github.com/EdenEast/nightfox.nvim/assets/11671510/9dc41848-e643-4f2c-b43b-fd77e45310d4)

Once it is fixed, I can make `use` bold, for example, like this.

![image](https://github.com/EdenEast/nightfox.nvim/assets/11671510/178589b6-ce20-4e94-9604-fda2f72b0fa3)

Example with C using `#include`.

![image](https://github.com/EdenEast/nightfox.nvim/assets/11671510/310995e9-3f65-4875-b619-c80a1e0d6b10)
![image](https://github.com/EdenEast/nightfox.nvim/assets/11671510/379fc08b-8417-4ee2-a031-afc140630fc4)

Fixes #429 