### PR TITLE
Update repo URL for neogit module

### DIFF
--- a/lua/nightfox/group/modules/neogit.lua
+++ b/lua/nightfox/group/modules/neogit.lua
@@ -1,4 +1,4 @@
--- https://github.com/TimUntersberger/neogit
+-- https://github.com/NeogitOrg/neogit
 
 local M = {}
 

--- a/readme.md
+++ b/readme.md
@@ -533,7 +533,7 @@ There are a few things to note:
 - [mini.nvim](https://github.com/echasnovski/mini.nvim)
 - [modes.nvim](https://github.com/mvllow/modes.nvim)
 - [nvim-navic](https://github.com/SmiteshP/nvim-navic)
-- [neogit](https://github.com/TimUntersberger/neogit)
+- [neogit](https://github.com/NeogitOrg/neogit)
 - [neotest](https://github.com/nvim-neotest/neotest)
 - [neo-tree](https://github.com/nvim-neo-tree/neo-tree.nvim)
 - [nvim-notify](https://github.com/rcarriga/nvim-notify)
@@ -635,7 +635,7 @@ There are [extra](./extra) configuration files for the following:
 - [oxocarbon.nvim](https://github.com/shaunsingh/oxocarbon.nvim) (carbonfox)
 - [coolers](https://coolers.co) (useful color information and palette tool)
 - [colorhexa](https://www.colorhexa.com/) (detailed color information)
-- [neogit](https://github.com/TimUntersberger/neogit/blob/b688a2c/lua/neogit/lib/color.lua) (base for color lib)
+- [neogit](https://github.com/NeogitOrg/neogit/blob/b688a2c/lua/neogit/lib/color.lua) (base for color lib)
 - [daltonlens](https://daltonlens.org/) (understanding cvd simulations and research. Thanks [@nburrus](https://github.com/nburrus)!)
 
 ## References


### PR DESCRIPTION
The repo URL for neogit has changed from
https://github.com/TimUntersberger/neogit to
https://github.com/NeogitOrg/neogit. This PR updates the repo URL.
