### PR TITLE
Update feline.lua

### DIFF
--- a/misc/feline.lua
+++ b/misc/feline.lua
@@ -367,7 +367,7 @@ local c = {
   },
   lsp_status = {
     provider = function()
-      return vim.tbl_count(vim.lsp.buf_get_clients(0)) == 0 and "" or " ◦ "
+      return vim.tbl_count(vim.lsp.get_clients { bufnr = 0 }) == 0 and "" or " ◦ "
     end,
     hl = "UserSLStatus",
     left_sep = { str = "", hl = "UserSLStatusBg", always_visible = true },


### PR DESCRIPTION
Using `vim.lsp.buf_get_clients` and querying the current buffer by the 0th index are deprecated in Nvim 0.12.

Changed to use `vim.lsp.get_clients` and with the buffer number provided.