### PR TITLE
Feat: Add python support to starship

### DIFF
--- a/extra/carbonfox/starship.toml
+++ b/extra/carbonfox/starship.toml
@@ -18,6 +18,7 @@ $git_status\
 $nodejs\
 $rust\
 $golang\
+$python\
 [](fg:lang_bg bg:background)\
 \n$character"""
 
@@ -133,7 +134,9 @@ format = '[[ $symbol( $version) ](fg:lang_fg bg:lang_bg)]($style)'
 [python]
 symbol = ""
 style = "bg:lang_bg"
-format = '[[ $symbol( $version) ](fg:lang_fg bg:lang_bg)]($style)'
+format = '[[ $symbol($virtualenv )($version) ](fg:lang_fg bg:lang_bg)]($style)'
+python_binary = ['.venv/bin/python']
+detect_extensions = ['py']
 
 [character]
 disabled = false

--- a/extra/dawnfox/starship.toml
+++ b/extra/dawnfox/starship.toml
@@ -18,6 +18,7 @@ $git_status\
 $nodejs\
 $rust\
 $golang\
+$python\
 [](fg:lang_bg bg:background)\
 \n$character"""
 
@@ -133,7 +134,9 @@ format = '[[ $symbol( $version) ](fg:lang_fg bg:lang_bg)]($style)'
 [python]
 symbol = ""
 style = "bg:lang_bg"
-format = '[[ $symbol( $version) ](fg:lang_fg bg:lang_bg)]($style)'
+format = '[[ $symbol($virtualenv )($version) ](fg:lang_fg bg:lang_bg)]($style)'
+python_binary = ['.venv/bin/python']
+detect_extensions = ['py']
 
 [character]
 disabled = false

--- a/extra/dayfox/starship.toml
+++ b/extra/dayfox/starship.toml
@@ -18,6 +18,7 @@ $git_status\
 $nodejs\
 $rust\
 $golang\
+$python\
 [](fg:lang_bg bg:background)\
 \n$character"""
 
@@ -133,7 +134,9 @@ format = '[[ $symbol( $version) ](fg:lang_fg bg:lang_bg)]($style)'
 [python]
 symbol = ""
 style = "bg:lang_bg"
-format = '[[ $symbol( $version) ](fg:lang_fg bg:lang_bg)]($style)'
+format = '[[ $symbol($virtualenv )($version) ](fg:lang_fg bg:lang_bg)]($style)'
+python_binary = ['.venv/bin/python']
+detect_extensions = ['py']
 
 [character]
 disabled = false

--- a/extra/duskfox/starship.toml
+++ b/extra/duskfox/starship.toml
@@ -18,6 +18,7 @@ $git_status\
 $nodejs\
 $rust\
 $golang\
+$python\
 [](fg:lang_bg bg:background)\
 \n$character"""
 
@@ -133,7 +134,9 @@ format = '[[ $symbol( $version) ](fg:lang_fg bg:lang_bg)]($style)'
 [python]
 symbol = ""
 style = "bg:lang_bg"
-format = '[[ $symbol( $version) ](fg:lang_fg bg:lang_bg)]($style)'
+format = '[[ $symbol($virtualenv )($version) ](fg:lang_fg bg:lang_bg)]($style)'
+python_binary = ['.venv/bin/python']
+detect_extensions = ['py']
 
 [character]
 disabled = false

--- a/extra/nightfox/starship.toml
+++ b/extra/nightfox/starship.toml
@@ -18,6 +18,7 @@ $git_status\
 $nodejs\
 $rust\
 $golang\
+$python\
 [](fg:lang_bg bg:background)\
 \n$character"""
 
@@ -133,7 +134,9 @@ format = '[[ $symbol( $version) ](fg:lang_fg bg:lang_bg)]($style)'
 [python]
 symbol = ""
 style = "bg:lang_bg"
-format = '[[ $symbol( $version) ](fg:lang_fg bg:lang_bg)]($style)'
+format = '[[ $symbol($virtualenv )($version) ](fg:lang_fg bg:lang_bg)]($style)'
+python_binary = ['.venv/bin/python']
+detect_extensions = ['py']
 
 [character]
 disabled = false

--- a/extra/nordfox/starship.toml
+++ b/extra/nordfox/starship.toml
@@ -18,6 +18,7 @@ $git_status\
 $nodejs\
 $rust\
 $golang\
+$python\
 [](fg:lang_bg bg:background)\
 \n$character"""
 
@@ -133,7 +134,9 @@ format = '[[ $symbol( $version) ](fg:lang_fg bg:lang_bg)]($style)'
 [python]
 symbol = ""
 style = "bg:lang_bg"
-format = '[[ $symbol( $version) ](fg:lang_fg bg:lang_bg)]($style)'
+format = '[[ $symbol($virtualenv )($version) ](fg:lang_fg bg:lang_bg)]($style)'
+python_binary = ['.venv/bin/python']
+detect_extensions = ['py']
 
 [character]
 disabled = false

--- a/extra/terafox/starship.toml
+++ b/extra/terafox/starship.toml
@@ -18,6 +18,7 @@ $git_status\
 $nodejs\
 $rust\
 $golang\
+$python\
 [](fg:lang_bg bg:background)\
 \n$character"""
 
@@ -133,7 +134,9 @@ format = '[[ $symbol( $version) ](fg:lang_fg bg:lang_bg)]($style)'
 [python]
 symbol = ""
 style = "bg:lang_bg"
-format = '[[ $symbol( $version) ](fg:lang_fg bg:lang_bg)]($style)'
+format = '[[ $symbol($virtualenv )($version) ](fg:lang_fg bg:lang_bg)]($style)'
+python_binary = ['.venv/bin/python']
+detect_extensions = ['py']
 
 [character]
 disabled = false


### PR DESCRIPTION
Summary
----

Typically users have python with a `.venv` folder in the project they're working on.

This adds python support to the starship prompt.

Example:
```
 starship explain

 Here's a breakdown of your prompt:
 " " (<1ms)                        -  A character (usually an arrow) beside where the text is entered in your terminal
 " ~/personal/python-test " (<1ms)  -  The current working directory
 "🍭 " (31ms)                       -  The current operating system
 " .venv v3.11.3 " (1ms)           -  The currently installed version of Python
 " rahul " (<1ms)                    -  The active user's username
```

Screenshot with nightfox starship toml:
![image](https://github.com/user-attachments/assets/02438326-f3dc-4f4c-9503-ca3267d304f8)

