### PR TITLE
Fix `@markup.italic`

### DIFF
--- a/lua/nightfox/group/modules/treesitter.lua
+++ b/lua/nightfox/group/modules/treesitter.lua
@@ -93,7 +93,7 @@ function M.get(spec, config, opts)
     -- Markup -----------------------------------------------------------------
     ["@markup"] = { fg = spec.fg1 }, -- For strings considerated text in a markup language.
     ["@markup.strong"] = { fg = P.red:subtle(), style = "bold" }, -- bold text
-    ["@markup.italic"] = { link = "" }, -- italic text
+    ["@markup.italic"] = { link = "Italic" }, -- italic text
     ["@markup.strikethrough"] = { fg = spec.fg1, style = "strikethrough" }, -- struck-through text
     ["@markup.underline"] = { link = "Underline" }, -- underlined text (only for literal underline markup!)
 


### PR DESCRIPTION
Fix italics for markup files.

Tested with both markdown and latex, both of which were broken.

Before:

![image](https://github.com/user-attachments/assets/6ac43109-1f48-43c0-ad47-2b35488110d1)

After:

![image](https://github.com/user-attachments/assets/a98f8285-cd5d-4208-ac24-4ac3acce74a3)