### PR TITLE
Add support for blink.cmp

### DIFF
--- a/lua/nightfox/config.lua
+++ b/lua/nightfox/config.lua
@@ -65,6 +65,7 @@ M.module_names = {
   "alpha",
   "aerial",
   "barbar",
+  "blink",
   "cmp",
   "coc",
   "dap_ui",

--- a/lua/nightfox/group/modules/blink.lua
+++ b/lua/nightfox/group/modules/blink.lua
@@ -1,0 +1,52 @@
+-- https://github.com/Saghen/blink.cmp
+-- Adapted links and colors from groups/modules/cmp.lua
+
+local M = {}
+
+function M.get(spec, config, opts)
+  local has_ts = config.modules.treesitter
+  local syn = spec.syntax
+
+  -- stylua: ignore
+  return {
+    BlinkCmpDoc         = { fg = spec.fg1, bg = spec.bg0 },
+    BlinkCmpDocBorder   = { fg = spec.sel0, bg = spec.bg0 },
+
+    BlinkCmpLabel              = { fg = spec.fg1, },
+    BlinkCmpLabelDeprecated    = { fg = syn.dep, style = "strikethrough" },
+    BlinkCmpLabelMatch         = { fg = syn.func, },
+
+    BlinkCmpKindDefault       = { fg = spec.fg2, },
+    BlinkCmpLabelDetail       = { link = "Comment" },
+
+    BlinkCmpKindKeyword       = { link = "Identifier" },
+
+    BlinkCmpKindVariable      = { link = has_ts and "@variable" or  "Identifier" },
+    BlinkCmpKindConstant      = { link = has_ts and "@constant" or "Constant" },
+    BlinkCmpKindReference     = { link = "Keyword" },
+    BlinkCmpKindValue         = { link = "Keyword" },
+
+    BlinkCmpKindFunction      = { link = "Function" },
+    BlinkCmpKindMethod        = { link = "Function" },
+    BlinkCmpKindConstructor   = { link = "Function" },
+
+    BlinkCmpKindInterface     = { link = "Constant" },
+    BlinkCmpKindEvent         = { link = "Constant" },
+    BlinkCmpKindEnum          = { link = "Constant" },
+    BlinkCmpKindUnit          = { link = "Constant" },
+
+    BlinkCmpKindClass         = { link = "Type" },
+    BlinkCmpKindStruct        = { link = "Type" },
+
+    BlinkCmpKindModule        = { link = has_ts and "@namespace"  or "Identifier" },
+
+    BlinkCmpKindProperty      = { link = has_ts and "@property" or  "Identifier" },
+    BlinkCmpKindField         = { link = has_ts and "@field" or "Identifier" },
+    BlinkCmpKindTypeParameter = { link = has_ts and "@field" or "Identifier" },
+    BlinkCmpKindEnumMember    = { link = has_ts and "@field" or "Identifier" },
+    BlinkCmpKindOperator      = { link = "Operator" },
+    BlinkCmpKindSnippet       = { fg = spec.fg2 },
+  }
+end
+
+return M


### PR DESCRIPTION
Hello, 

Lately [blink.cmp](https://github.com/Saghen/blink.cmp) has been gaining popularity and has its own hlgroups for completion menus, similar to nvim-cmp.

While it currently has support for mapping to the nvim-cmp hlgroups with its setting `appearance.use_nvim_cmp_as_default`, eventually this may be removed once colorschemes support it more ubiquitously.

I adapted the colors and links directly from the existing cmp module, so please feel free to adjust anything to better suit the theme's visuals.