### PR TITLE
Fix: vim_cache_home() return wrong path on Windows

### DIFF
--- a/lua/nightfox/util/init.lua
+++ b/lua/nightfox/util/init.lua
@@ -63,7 +63,7 @@ end
 
 local function vim_cache_home()
   if M.is_windows then
-    return M.join_paths(vim.fn.expand("%localappdata%"), "Temp", "vim")
+    return M.join_paths(vim.fn.expand("$localappdata"), "Temp", "vim")
   end
   local xdg = os.getenv("XDG_CACHE_HOME")
   local root = xdg or vim.fn.expand("$HOME/.cache")


### PR DESCRIPTION
Fixed an issue where the expansion of the `localappdata` environment variable failed because the argument for the `expand` function in `vim_cache_home()` was set to `%localappdata%` instead of `$localappdata`.